### PR TITLE
Add BLOCK opcode and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Turing complete thanks to arithmetic, memory access and branching opcodes.
 | `JZ o`      | Jump if zero              |
 | `JNZ o`     | Jump if non‑zero          |
 | `PRINT`     | Pop value and output      |
+| `BLOCK n`   | Run next `n` chunks in new VM |
+| `NTT n`     | NTT roundtrip next `n` chunks |
 
 Negative jump offsets are encoded using a special `NEG_FLAG` prime.  Memory is
 an unbounded dictionary of integer addresses.
@@ -29,11 +31,18 @@ an unbounded dictionary of integer addresses.
 ```bash
 python3 uor-cli.py assemble program.asm   # assemble to chunks
 python3 uor-cli.py run program.asm        # assemble and execute
+python3 uor-cli.py run program.uor        # run pre-encoded program
 ```
 
 Assembly files consist of one instruction per line with optional labels and
 `#` comments.  Offsets for jumps can reference labels and will be translated to
 relative jumps automatically.
+
+## Examples
+
+Two sample programs are provided in the `examples/` directory.  `countdown.asm`
+implements a simple loop that prints `321`.  `block_demo.asm` demonstrates the
+`BLOCK` opcode by executing a small block which prints `HI`.
 
 ## Tests
 

--- a/assembler.py
+++ b/assembler.py
@@ -66,6 +66,14 @@ def assemble(text: str) -> List[int]:
             if arg is None:
                 raise ValueError("JNZ requires offset")
             result.append(chunks.chunk_jnz(int(arg)))
+        elif op == "BLOCK":
+            if arg is None:
+                raise ValueError("BLOCK requires length")
+            result.append(chunks.chunk_block_start(int(arg)))
+        elif op == "NTT":
+            if arg is None:
+                raise ValueError("NTT requires length")
+            result.append(chunks.chunk_ntt(int(arg)))
         else:
             raise ValueError(f"Unknown instruction: {op}")
 

--- a/examples/block_demo.asm
+++ b/examples/block_demo.asm
@@ -1,0 +1,6 @@
+# Execute a small block that prints "HI"
+BLOCK 4
+PUSH 72
+PRINT
+PUSH 73
+PRINT

--- a/examples/countdown.asm
+++ b/examples/countdown.asm
@@ -1,0 +1,13 @@
+PUSH 3
+STORE 0
+start:
+LOAD 0
+JZ end
+LOAD 0
+PRINT
+LOAD 0
+PUSH 1
+SUB
+STORE 0
+JMP start
+end:

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,0 +1,19 @@
+import unittest
+import assembler
+from vm import VM
+
+class BlockOpcodeTest(unittest.TestCase):
+    def test_block_executes_sub_vm(self):
+        src = """
+        BLOCK 4
+        PUSH 1
+        PUSH 2
+        ADD
+        PRINT
+        """
+        prog = assembler.assemble(src)
+        out = ''.join(VM().execute(prog))
+        self.assertEqual(out, '3')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uor-cli.py
+++ b/uor-cli.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Command line interface for the Pure UOR VM."""
+"""Command line interface for the Pure UOR VM.
+
+The tool can assemble text programs into numeric chunks or execute an
+assembly file directly.  If a ``.uor`` file is given, its numbers are
+loaded and executed through the VM.
+"""
 from __future__ import annotations
 
 import argparse
@@ -38,7 +43,7 @@ def build_parser() -> argparse.ArgumentParser:
     pa.set_defaults(func=cmd_assemble)
 
     pr = sub.add_parser('run', help='assemble and run program')
-    pr.add_argument('source')
+    pr.add_argument('source', help='source .asm or encoded .uor file')
     pr.set_defaults(func=cmd_run)
 
     return p

--- a/vm.py
+++ b/vm.py
@@ -46,7 +46,10 @@ class VM:
                     chk = p
                     e -= 6
                 elif e >= 6:
-                    raise ValueError("Duplicate checksum")
+                    if p == BLOCK_TAG and e == 7:
+                        pass
+                    else:
+                        raise ValueError("Duplicate checksum")
                 if e:
                     data.append((p, e))
             if chk is None:


### PR DESCRIPTION
## Summary
- implement BLOCK and NTT assembly instructions
- relax VM checksum check so BLOCK tags work
- document new opcodes and CLI features
- add example assembly programs
- test BLOCK opcode via a new unit test

## Testing
- `python3 -m unittest discover -v`