### PR TITLE
Fix factor caching bug

### DIFF
--- a/primes.py
+++ b/primes.py
@@ -52,6 +52,7 @@ def get_prime(idx: int) -> int:
 def factor(x: int) -> List[Tuple[int, int]]:
     if x in _FACTOR_CACHE:
         return list(_FACTOR_CACHE[x])
+    orig = x
     fac: List[Tuple[int, int]] = []
     i = 0
     while True:
@@ -70,5 +71,5 @@ def factor(x: int) -> List[Tuple[int, int]]:
             _PRIME_IDX[x] = len(_PRIMES)
             _PRIMES.append(x)
         fac.append((x, 1))
-    _FACTOR_CACHE[x] = list(fac)
+    _FACTOR_CACHE[orig] = list(fac)
     return fac

--- a/tests/test_primes.py
+++ b/tests/test_primes.py
@@ -1,7 +1,7 @@
 import time
 import unittest
 
-from primes import get_prime
+from primes import get_prime, factor, _FACTOR_CACHE
 
 
 def naive_get_prime(idx: int) -> int:
@@ -27,6 +27,15 @@ class PrimeBenchTest(unittest.TestCase):
         get_prime(idx)
         sieve_time = time.time() - start
         self.assertLess(sieve_time, naive_time)
+
+
+class FactorRegressionTest(unittest.TestCase):
+    def test_factor_cache_original_input(self):
+        _FACTOR_CACHE.clear()
+        result = factor(12)
+        self.assertEqual(result, [(2, 2), (3, 1)])
+        self.assertIn(12, _FACTOR_CACHE)
+        self.assertEqual(_FACTOR_CACHE[12], result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid mutating the cache key in `primes.factor`
- add regression tests for `factor(12)`

## Testing
- `pytest -q`