### PR TITLE
Add assembler and primes cache tests

### DIFF
--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -26,6 +26,43 @@ class AssemblerTest(unittest.TestCase):
         out = ''.join(VM().execute(prog))
         self.assertEqual(out, '321')
 
+    def test_numeric_negative_jump(self):
+        src = """
+        PUSH 3
+        STORE 0
+        LOAD 0
+        PRINT
+        LOAD 0
+        PUSH 1
+        SUB
+        STORE 0
+        LOAD 0
+        JNZ -8
+        """
+        prog = assembler.assemble(src)
+        out = ''.join(VM().execute(prog))
+        self.assertEqual(out, '321')
+
+    def test_label_resolution_forward(self):
+        src = """
+        JMP end
+        PUSH 1
+        end:
+        PUSH 2
+        PRINT
+        """
+        prog = assembler.assemble(src)
+        out = ''.join(VM().execute(prog))
+        self.assertEqual(out, '2')
+
+    def test_unknown_label_error(self):
+        with self.assertRaises(ValueError):
+            assembler.assemble("JMP nowhere")
+
+    def test_invalid_instruction_error(self):
+        with self.assertRaises(ValueError):
+            assembler.assemble("FOO 1")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_primes.py
+++ b/tests/test_primes.py
@@ -37,6 +37,23 @@ class FactorRegressionTest(unittest.TestCase):
         self.assertIn(12, _FACTOR_CACHE)
         self.assertEqual(_FACTOR_CACHE[12], result)
 
+    def test_factor_cache_returns_copy(self):
+        _FACTOR_CACHE.clear()
+        result1 = factor(12)
+        result1.append((5, 1))
+        self.assertIn(12, _FACTOR_CACHE)
+        self.assertEqual(_FACTOR_CACHE[12], [(2, 2), (3, 1)])
+        result2 = factor(12)
+        self.assertEqual(result2, [(2, 2), (3, 1)])
+        self.assertIsNot(result2, _FACTOR_CACHE[12])
+
+    def test_factor_cache_reused(self):
+        _FACTOR_CACHE.clear()
+        factor(18)
+        cache_snapshot = dict(_FACTOR_CACHE)
+        factor(18)
+        self.assertEqual(_FACTOR_CACHE, cache_snapshot)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expand assembler tests to cover numeric negative jumps, label resolution, and error handling
- extend prime factorization tests for cache reuse and return-value copying

## Testing
- `pytest -q`