### PR TITLE
Introduce decoded instruction format

### DIFF
--- a/decoder.py
+++ b/decoder.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from primes import get_prime, _PRIME_IDX, factor
+from chunks import BLOCK_TAG, NTT_TAG
+
+
+@dataclass
+class DecodedInstruction:
+    data: List[Tuple[int, int]]
+    inner: List['DecodedInstruction'] | None = None
+
+
+def _decode_single(chunk: int) -> List[Tuple[int, int]]:
+    fac = factor(chunk)
+    chk = None
+    data: List[Tuple[int, int]] = []
+    for p, e in fac:
+        if e >= 6 and chk is None:
+            chk = p
+            e -= 6
+        elif e >= 6:
+            if p == BLOCK_TAG and e == 7:
+                pass
+            else:
+                raise ValueError("Duplicate checksum")
+        if e:
+            data.append((p, e))
+    if chk is None:
+        raise ValueError("Checksum missing")
+    xor = 0
+    for p, e in data:
+        xor ^= _PRIME_IDX[p] * e
+    if chk != get_prime(xor):
+        raise ValueError("Checksum mismatch")
+    return data
+
+
+def decode(chunks: List[int]) -> List[DecodedInstruction]:
+    result: List[DecodedInstruction] = []
+    ip = 0
+    while ip < len(chunks):
+        ck = chunks[ip]
+        ip += 1
+        data = _decode_single(ck)
+        inner: List[DecodedInstruction] | None = None
+        if any(p == BLOCK_TAG and e == 7 for p, e in data):
+            lp = next(p for p, e in data if p != BLOCK_TAG and e == 5)
+            cnt = _PRIME_IDX[lp]
+            inner = decode(chunks[ip:ip + cnt])
+            ip += cnt
+        elif any(p == NTT_TAG and e == 4 for p, e in data):
+            lp = next(p for p, e in data if p != NTT_TAG and e == 5)
+            cnt = _PRIME_IDX[lp]
+            inner = decode(chunks[ip:ip + cnt])
+            ip += cnt
+        result.append(DecodedInstruction(data=data, inner=inner))
+    return result

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -3,6 +3,7 @@ import unittest
 import assembler
 import chunks
 from vm import VM
+from decoder import decode
 
 
 class AssemblerTest(unittest.TestCase):
@@ -23,7 +24,7 @@ class AssemblerTest(unittest.TestCase):
         end:
         """
         prog = assembler.assemble(src)
-        out = ''.join(VM().execute(prog))
+        out = ''.join(VM().execute(decode(prog)))
         self.assertEqual(out, '321')
 
     def test_numeric_negative_jump(self):
@@ -40,7 +41,7 @@ class AssemblerTest(unittest.TestCase):
         JNZ -8
         """
         prog = assembler.assemble(src)
-        out = ''.join(VM().execute(prog))
+        out = ''.join(VM().execute(decode(prog)))
         self.assertEqual(out, '321')
 
     def test_label_resolution_forward(self):
@@ -52,7 +53,7 @@ class AssemblerTest(unittest.TestCase):
         PRINT
         """
         prog = assembler.assemble(src)
-        out = ''.join(VM().execute(prog))
+        out = ''.join(VM().execute(decode(prog)))
         self.assertEqual(out, '2')
 
     def test_unknown_label_error(self):

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,35 @@
+import time
+import unittest
+
+import assembler
+from vm import VM
+from decoder import decode
+
+
+class DecodeBenchTest(unittest.TestCase):
+    def test_reuse_decoded_program_faster(self):
+        src = """
+        PUSH 1
+        PUSH 2
+        ADD
+        PRINT
+        """
+        prog = assembler.assemble(src)
+        runs = 200
+
+        start = time.time()
+        for _ in range(runs):
+            VM().execute(decode(prog))
+        fresh_time = time.time() - start
+
+        decoded = decode(prog)
+        start = time.time()
+        for _ in range(runs):
+            VM().execute(decoded)
+        reused_time = time.time() - start
+
+        self.assertLess(reused_time, fresh_time)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,6 +1,7 @@
 import unittest
 import assembler
 from vm import VM
+from decoder import decode
 
 class BlockOpcodeTest(unittest.TestCase):
     def test_block_executes_sub_vm(self):
@@ -12,7 +13,7 @@ class BlockOpcodeTest(unittest.TestCase):
         PRINT
         """
         prog = assembler.assemble(src)
-        out = ''.join(VM().execute(prog))
+        out = ''.join(VM().execute(decode(prog)))
         self.assertEqual(out, '3')
 
 if __name__ == '__main__':

--- a/tests/test_ntt.py
+++ b/tests/test_ntt.py
@@ -2,12 +2,13 @@ import unittest
 import assembler
 import chunks
 from vm import VM
+from decoder import decode
 
 class NTTTest(unittest.TestCase):
     def test_ntt_roundtrip(self):
         prog = assembler.assemble("NTT 3")
         prog += [chunks.chunk_data(i, ord(c)) for i, c in enumerate("XYZ")]
-        out = ''.join(VM().execute(prog))
+        out = ''.join(VM().execute(decode(prog)))
         self.assertEqual(out, 'XYZ')
 
 if __name__ == '__main__':

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -2,6 +2,7 @@ import unittest
 
 import chunks
 from vm import VM
+from decoder import decode
 
 
 class VMTest(unittest.TestCase):
@@ -12,7 +13,7 @@ class VMTest(unittest.TestCase):
             chunks.chunk_add(),
             chunks.chunk_print(),
         ]
-        out = ''.join(VM().execute(prog))
+        out = ''.join(VM().execute(decode(prog)))
         self.assertEqual(out, '5')
 
     def test_memory(self):
@@ -22,7 +23,7 @@ class VMTest(unittest.TestCase):
             chunks.chunk_load(0),
             chunks.chunk_print(),
         ]
-        out = ''.join(VM().execute(prog))
+        out = ''.join(VM().execute(decode(prog)))
         self.assertEqual(out, '7')
 
 

--- a/uor-cli.py
+++ b/uor-cli.py
@@ -11,6 +11,7 @@ import argparse
 import sys
 
 from vm import VM
+from decoder import decode
 import chunks
 import assembler
 
@@ -45,7 +46,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     else:
         chunks_list = assembler.assemble_file(args.source)
     vm = VM()
-    output = ''.join(vm.execute(chunks_list))
+    output = ''.join(vm.execute(decode(chunks_list)))
     print(output)
     return 0
 

--- a/uor.py
+++ b/uor.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 import primes
 import chunks
 from vm import VM
+from decoder import decode
 
 # Opcode aliases for backwards compatibility
 OP_PUSH = chunks.OP_PUSH
@@ -40,7 +41,7 @@ chunk_ntt = chunks.chunk_ntt
 
 def vm_execute(prog: List[int]):
     """Execute program using the built-in VM."""
-    return VM().execute(prog)
+    return VM().execute(decode(prog))
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -60,10 +61,10 @@ def _self_tests() -> Tuple[int, int]:
             print("FAIL", msg)
 
     ok((chunks.OP_PUSH, chunks.OP_ADD, chunks.OP_PRINT) == (2, 3, 5), "primes")
-    ok("".join(vm.execute([chunk_data(i, ord(c)) for i, c in enumerate("Hi")])) == "Hi", "roundtrip")
+    ok("".join(vm.execute(decode([chunk_data(i, ord(c)) for i, c in enumerate("Hi")]))) == "Hi", "roundtrip")
     seq = [chunk_data(i, ord(c)) for i, c in enumerate("XYZ")]
     prog = [chunk_ntt(3)] + seq
-    ok("".join(VM().execute(prog)) == "XYZ", "ntt roundtrip")
+    ok("".join(VM().execute(decode(prog))) == "XYZ", "ntt roundtrip")
 
     prog_mem = [
         chunk_push(10),
@@ -71,7 +72,7 @@ def _self_tests() -> Tuple[int, int]:
         chunk_load(0),
         chunk_print(),
     ]
-    ok("".join(VM().execute(prog_mem)) == "10", "memory")
+    ok("".join(VM().execute(decode(prog_mem))) == "10", "memory")
 
     prog_loop = [
         chunk_push(3),
@@ -86,7 +87,7 @@ def _self_tests() -> Tuple[int, int]:
         chunk_store(0),
         chunk_jmp(-9),
     ]
-    ok("".join(VM().execute(prog_loop)) == "321", "loop")
+    ok("".join(VM().execute(decode(prog_loop))) == "321", "loop")
 
     # Stress-test prime factorization with large numbers
     large = primes.get_prime(1000) * primes.get_prime(1100)
@@ -112,4 +113,4 @@ if __name__ == "__main__":
     print("\nDemo ▶ Encoding chunks:")
     print(" ".join(str(x) for x in stream))
     print("Demo ▶ Decoded text:")
-    print("".join(vm.execute(stream)))
+    print("".join(vm.execute(decode(stream))))


### PR DESCRIPTION
## Summary
- add `decoder.decode` for factoring instruction streams once
- update `VM.execute` to consume decoded instructions
- adjust CLI, helper API and tests for new decode step
- add benchmark verifying reuse of decoded programs is faster

## Testing
- `python3 -m unittest discover -v`