### PR TITLE
Update docs and expose IPFS helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,23 @@ Unit tests reside in `tests/`.  Run them with:
 python3 -m unittest discover -v
 ```
 
+
+## Optional IPFS Support
+
+The module `uor.ipfs_storage` provides helpers for storing and retrieving
+programs via [IPFS](https://ipfs.tech/). To use it you must install the optional
+dependency and have an IPFS daemon running locally:
+
+```bash
+pip install -r requirements.txt
+ipfs daemon &
+```
+
+Two additional CLI commands allow storing programs in IPFS and executing them
+by CID:
+
+```bash
+python3 uor-cli.py ipfs-add examples/countdown.asm
+python3 uor-cli.py ipfs-run <CID>
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ipfshttpclient~=0.8

--- a/tests/test_cli_ipfs.py
+++ b/tests/test_cli_ipfs.py
@@ -1,0 +1,38 @@
+import io
+import os
+import contextlib
+import importlib.util
+import unittest
+from unittest import mock
+
+# Load the CLI module since its filename contains a dash
+spec = importlib.util.spec_from_file_location('uor_cli', os.path.join(os.path.dirname(__file__), '..', 'uor-cli.py'))
+uor_cli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(uor_cli)
+
+import assembler
+
+class CLIIpfsTest(unittest.TestCase):
+    def test_ipfs_add_prints_cid(self):
+        with mock.patch('uor.ipfs_storage.add_data', return_value='CID') as add:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = uor_cli.main(['ipfs-add', 'examples/countdown.asm'])
+            self.assertEqual(rc, 0)
+            self.assertEqual(buf.getvalue().strip(), 'CID')
+            add.assert_called()
+
+    def test_ipfs_run_executes_program(self):
+        program = assembler.assemble_file('examples/countdown.asm')
+        data = '\n'.join(str(x) for x in program).encode('utf-8')
+        with mock.patch('uor.ipfs_storage.get_data', return_value=data) as get:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = uor_cli.main(['ipfs-run', 'fakecid'])
+            self.assertEqual(rc, 0)
+            self.assertEqual(buf.getvalue().strip(), '321')
+            get.assert_called_with('fakecid')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ipfs_storage.py
+++ b/tests/test_ipfs_storage.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+import unittest
+from unittest import mock
+
+
+class IPFSStorageTest(unittest.TestCase):
+    def setUp(self):
+        self.fake_module = mock.MagicMock()
+        self.patcher = mock.patch.dict(sys.modules, {'ipfshttpclient': self.fake_module})
+        self.patcher.start()
+        import uor.ipfs_storage
+        self.mod = importlib.reload(uor.ipfs_storage)
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_add_data(self):
+        fake_client = mock.MagicMock()
+        fake_client.__enter__.return_value = fake_client
+        fake_client.add_bytes.return_value = 'CID'
+        self.fake_module.connect.return_value = fake_client
+        cid = self.mod.add_data(b'hello')
+        fake_client.add_bytes.assert_called_with(b'hello')
+        self.assertEqual(cid, 'CID')
+
+    def test_get_data(self):
+        fake_client = mock.MagicMock()
+        fake_client.__enter__.return_value = fake_client
+        fake_client.cat.return_value = b'data'
+        self.fake_module.connect.return_value = fake_client
+        data = self.mod.get_data('CID')
+        fake_client.cat.assert_called_with('CID')
+        self.assertEqual(data, b'data')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uor/__init__.py
+++ b/uor/__init__.py
@@ -1,1 +1,7 @@
 """Utilities and helpers for the Pure UOR VM."""
+
+from . import ipfs_storage
+
+__all__ = [
+    "ipfs_storage",
+]

--- a/uor/ipfs_storage.py
+++ b/uor/ipfs_storage.py
@@ -1,0 +1,32 @@
+"""Utility helpers for storing programs in IPFS."""
+from __future__ import annotations
+
+try:
+    import ipfshttpclient  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency not installed
+    ipfshttpclient = None
+
+
+def _require_client() -> None:
+    if ipfshttpclient is None:
+        raise RuntimeError("ipfshttpclient is not installed")
+
+
+def add_data(data: bytes) -> str:
+    """Add ``data`` to IPFS and return its CID."""
+    _require_client()
+    try:
+        with ipfshttpclient.connect() as client:  # type: ignore[attr-defined]
+            return client.add_bytes(data)
+    except Exception as exc:  # ipfshttpclient errors are broad
+        raise RuntimeError("Failed to add data to IPFS") from exc
+
+
+def get_data(cid: str) -> bytes:
+    """Retrieve data from IPFS by ``cid``."""
+    _require_client()
+    try:
+        with ipfshttpclient.connect() as client:  # type: ignore[attr-defined]
+            return client.cat(cid)
+    except Exception as exc:
+        raise RuntimeError("Failed to fetch data from IPFS") from exc


### PR DESCRIPTION
## Summary
- reintroduce IPFS CLI commands and tests
- document optional IPFS usage and commands in README
- expose `ipfs_storage` from `uor.__init__`

## Testing
- `python3 -m unittest discover -v`