### PR TITLE
Add unified LLM client

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ pip install -r requirements.txt
 ipfs daemon &
 ```
 
+## LLM API Keys
+
+The upcoming LLM helpers require API credentials. Set the following environment
+variables for the providers you want to use:
+
+```bash
+export OPENAI_API_KEY=your-openai-key
+export ANTHROPIC_API_KEY=your-anthropic-key
+export GOOGLE_API_KEY=your-gemini-key
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 ipfshttpclient~=0.8
+openai
+anthropic
+google-generativeai
+flask

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,89 @@
+import importlib
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _load_module(modules: dict[str, object]):
+    with mock.patch.dict(sys.modules, modules):
+        sys.modules.pop('uor.llm_client', None)
+        import uor.llm_client as lc
+        return importlib.reload(lc)
+
+
+class LLMClientTest(unittest.TestCase):
+    def test_openai(self):
+        fake_openai = types.ModuleType('openai')
+        chat = mock.MagicMock()
+        fake_openai.ChatCompletion = chat
+        resp = mock.MagicMock()
+        resp.choices = [mock.MagicMock(message=mock.MagicMock(content='ok'))]
+        chat.create.return_value = resp
+
+        modules = {
+            'openai': fake_openai,
+            'anthropic': types.ModuleType('anthropic'),
+            'google': types.ModuleType('google'),
+            'google.generativeai': mock.MagicMock(),
+        }
+        with mock.patch.dict(os.environ, {'OPENAI_API_KEY': 'k'}):
+            mod = _load_module(modules)
+            result = mod.call_model('openai', 'hi')
+        self.assertEqual(result, 'ok')
+        chat.create.assert_called()
+
+    def test_anthropic(self):
+        fake_anthropic = types.ModuleType('anthropic')
+        client_inst = mock.MagicMock()
+        fake_anthropic.Anthropic = mock.MagicMock(return_value=client_inst)
+        resp = mock.MagicMock(content='anthro')
+        client_inst.messages.create.return_value = resp
+
+        modules = {
+            'openai': types.ModuleType('openai'),
+            'anthropic': fake_anthropic,
+            'google': types.ModuleType('google'),
+            'google.generativeai': mock.MagicMock(),
+        }
+        with mock.patch.dict(os.environ, {'ANTHROPIC_API_KEY': 'k'}):
+            mod = _load_module(modules)
+            result = mod.call_model('anthropic', 'hi')
+        self.assertEqual(result, 'anthro')
+        client_inst.messages.create.assert_called()
+
+    def test_gemini(self):
+        fake_google = types.ModuleType('google')
+        genai = mock.MagicMock()
+        fake_google.generativeai = genai
+        resp = mock.MagicMock(text='gem')
+        model = mock.MagicMock(generate_content=mock.MagicMock(return_value=resp))
+        genai.GenerativeModel.return_value = model
+
+        modules = {
+            'openai': types.ModuleType('openai'),
+            'anthropic': types.ModuleType('anthropic'),
+            'google': fake_google,
+            'google.generativeai': genai,
+        }
+        with mock.patch.dict(os.environ, {'GOOGLE_API_KEY': 'k'}):
+            mod = _load_module(modules)
+            result = mod.call_model('gemini', 'hi')
+        self.assertEqual(result, 'gem')
+        model.generate_content.assert_called_with('hi')
+
+    def test_unknown_provider(self):
+        modules = {
+            'openai': types.ModuleType('openai'),
+            'anthropic': types.ModuleType('anthropic'),
+            'google': types.ModuleType('google'),
+            'google.generativeai': mock.MagicMock(),
+        }
+        mod = _load_module(modules)
+        with self.assertRaises(ValueError):
+            mod.call_model('foo', 'hi')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uor/llm_client.py
+++ b/uor/llm_client.py
@@ -1,0 +1,76 @@
+"""Unified client helpers for calling LLM providers."""
+from __future__ import annotations
+
+import os
+
+try:
+    import openai  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional
+    openai = None  # type: ignore
+
+try:
+    import anthropic  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional
+    anthropic = None  # type: ignore
+
+try:
+    import google.generativeai as generativeai  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional
+    generativeai = None  # type: ignore
+
+
+class MissingDependencyError(RuntimeError):
+    """Raised when a required client library is missing."""
+
+
+def _require(module: object | None, name: str) -> None:
+    if module is None:
+        raise MissingDependencyError(f"{name} library is not installed")
+
+
+def _get_env(key: str) -> str:
+    value = os.getenv(key)
+    if not value:
+        raise RuntimeError(f"Environment variable {key} is required")
+    return value
+
+
+def call_model(provider: str, prompt: str) -> str:
+    """Send ``prompt`` to the given ``provider`` and return the response text."""
+    provider = provider.lower()
+    if provider == "openai":
+        _require(openai, "openai")
+        openai.api_key = _get_env("OPENAI_API_KEY")
+        try:
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return resp.choices[0].message.content
+        except Exception as exc:  # pragma: no cover - network errors
+            raise RuntimeError("Failed to call OpenAI") from exc
+
+    if provider == "anthropic":
+        _require(anthropic, "anthropic")
+        try:
+            client = anthropic.Anthropic(api_key=_get_env("ANTHROPIC_API_KEY"))
+            resp = client.messages.create(
+                model="claude-3-opus-20240229",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return getattr(resp, "content", getattr(resp, "completion"))
+        except Exception as exc:  # pragma: no cover - network errors
+            raise RuntimeError("Failed to call Anthropic") from exc
+
+    if provider in {"gemini", "google"}:
+        _require(generativeai, "google-generativeai")
+        try:
+            generativeai.configure(api_key=_get_env("GOOGLE_API_KEY"))
+            model = generativeai.GenerativeModel("gemini-pro")
+            resp = model.generate_content(prompt)
+            return resp.text
+        except Exception as exc:  # pragma: no cover - network errors
+            raise RuntimeError("Failed to call Gemini") from exc
+
+    raise ValueError(f"Unknown provider: {provider}")
+


### PR DESCRIPTION
## Summary
- add `uor/llm_client.py` to unify OpenAI, Anthropic, and Gemini calls
- mock LLM providers in new `tests/test_llm_client.py`

## Testing
- `python3 -m unittest discover -v`