### PR TITLE
Add Flask API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,29 @@ pip install -r requirements.txt
 ipfs daemon &
 ```
 
+## LLM API Keys
+
+The upcoming LLM helpers require API credentials. Set the following environment
+variables for the providers you want to use:
+
+```bash
+export OPENAI_API_KEY=your-openai-key
+export ANTHROPIC_API_KEY=your-anthropic-key
+export GOOGLE_API_KEY=your-gemini-key
+```
+
+## HTTP API Server
+
+Run a small Flask app that exposes endpoints for front-end integrations:
+
+```bash
+python3 run_server.py
+```
+
+Available endpoints:
+
+- `POST /generate` – JSON body `{"provider": "openai", "prompt": "..."}`
+  assembles the LLM response, stores it to IPFS and returns `{"cid": "..."}`.
+- `GET /run/<cid>` – executes an encoded program stored under the given CID
+  and returns its output as JSON.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 ipfshttpclient~=0.8
+openai
+anthropic
+google-generativeai
+flask

--- a/run_server.py
+++ b/run_server.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Convenience script to start the HTTP API server."""
+from uor.api_server import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest import mock
+
+import assembler
+from uor import api_server
+try:
+    import flask  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    flask = None
+
+create_app = api_server.create_app
+
+
+class APIServerTest(unittest.TestCase):
+    def setUp(self):
+        if flask is None:
+            self.skipTest('flask not installed')
+        self.app = create_app().test_client()
+
+    def test_generate_endpoint(self):
+        program_text = "PUSH 1\nPRINT"
+        encoded = "\n".join(str(x) for x in assembler.assemble(program_text)).encode("utf-8")
+        with mock.patch('uor.llm_client.call_model', return_value=program_text) as call_model, \
+             mock.patch('uor.ipfs_storage.add_data', return_value='CID') as add_data:
+            resp = self.app.post('/generate', json={'provider': 'openai', 'prompt': 'hi'})
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.get_json(), {'cid': 'CID'})
+            call_model.assert_called_with('openai', 'hi')
+            add_data.assert_called_with(encoded)
+
+    def test_run_endpoint(self):
+        program_text = "PUSH 5\nPRINT"
+        encoded = "\n".join(str(x) for x in assembler.assemble(program_text)).encode("utf-8")
+        with mock.patch('uor.ipfs_storage.get_data', return_value=encoded) as get_data:
+            resp = self.app.get('/run/XYZ')
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.get_json(), {'output': '5'})
+            get_data.assert_called_with('XYZ')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uor/api_server.py
+++ b/uor/api_server.py
@@ -1,0 +1,50 @@
+"""HTTP API server for generating and running programs."""
+from __future__ import annotations
+
+from typing import Any
+
+import assembler
+from decoder import decode
+from vm import VM
+from . import llm_client, ipfs_storage
+
+
+def create_app() -> "Flask":
+    try:
+        from flask import Flask, request, jsonify
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("Flask is not installed") from exc
+
+    app = Flask(__name__)
+
+    @app.after_request
+    def add_cors(resp):
+        resp.headers.setdefault("Access-Control-Allow-Origin", "*")
+        return resp
+
+    @app.post("/generate")
+    def generate() -> Any:
+        data = request.get_json(force=True)
+        provider = data.get("provider")
+        prompt = data.get("prompt")
+        if not provider or not prompt:
+            return jsonify({"error": "provider and prompt required"}), 400
+        try:
+            asm = llm_client.call_model(provider, prompt)
+            program = assembler.assemble(asm)
+            cid = ipfs_storage.add_data("\n".join(str(x) for x in program).encode("utf-8"))
+            return jsonify({"cid": cid})
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            return jsonify({"error": str(exc)}), 500
+
+    @app.get("/run/<cid>")
+    def run(cid: str) -> Any:
+        try:
+            data = ipfs_storage.get_data(cid)
+            program = [int(x) for x in data.decode("utf-8").split() if x]
+            output = "".join(VM().execute(decode(program)))
+            return jsonify({"output": output})
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            return jsonify({"error": str(exc)}), 500
+
+    return app

--- a/uor/llm_client.py
+++ b/uor/llm_client.py
@@ -1,0 +1,35 @@
+"""Unified LLM client helpers."""
+from __future__ import annotations
+
+import os
+
+
+def call_model(provider: str, prompt: str) -> str:
+    """Call the selected model with ``prompt`` and return the text response."""
+    provider = provider.lower()
+    if provider == "openai":
+        import openai
+        key = os.environ.get("OPENAI_API_KEY")
+        if not key:
+            raise RuntimeError("OPENAI_API_KEY not set")
+        openai.api_key = key
+        resp = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": prompt}])
+        return resp.choices[0].message.content.strip()
+    if provider == "anthropic":
+        import anthropic
+        key = os.environ.get("ANTHROPIC_API_KEY")
+        if not key:
+            raise RuntimeError("ANTHROPIC_API_KEY not set")
+        client = anthropic.Anthropic(api_key=key)
+        resp = client.messages.create(model="claude-3-haiku-20240307", messages=[{"role": "user", "content": prompt}])
+        return resp.content[0].text.strip()
+    if provider == "gemini":
+        import google.generativeai as genai
+        key = os.environ.get("GOOGLE_API_KEY")
+        if not key:
+            raise RuntimeError("GOOGLE_API_KEY not set")
+        genai.configure(api_key=key)
+        model = genai.GenerativeModel("gemini-pro")
+        resp = model.generate_content(prompt)
+        return resp.text.strip()
+    raise ValueError(f"Unknown provider: {provider}")


### PR DESCRIPTION
## Summary
- add HTTP API server with endpoints for LLM code generation and running CIDs
- expose convenience `run_server.py` to start the server
- implement unified LLM client helper
- document new API in the README
- test API server behaviour (skips when Flask is not installed)

## Testing
- `python3 -m unittest discover -v`