### PR TITLE
Add async LLM client and agent factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,17 @@ export ANTHROPIC_API_KEY=your-anthropic-key
 export GOOGLE_API_KEY=your-gemini-key
 ```
 
+
+## Asynchronous LLM Helper
+
+Use `uor.async_llm_client.async_call_model` when coordinating multiple agents concurrently. It mirrors `llm_client.call_model` but returns a coroutine that can be awaited.
+
+## Agent Factory
+
+Specialized agents (planner, coder and tester) live under `uor.agents`. The `AppFactory` orchestrates them to create new apps and store the result via IPFS. Run this process through the CLI:
+
+```bash
+python3 uor-cli.py factory "your goal"            # uses OpenAI by default
+```
+
+Pass `--provider` to select another LLM backend.

--- a/tests/test_async_llm_client.py
+++ b/tests/test_async_llm_client.py
@@ -1,0 +1,92 @@
+import importlib
+import os
+import sys
+import types
+import unittest
+import asyncio
+from unittest import mock
+
+
+def _load_module(modules: dict[str, object]):
+    with mock.patch.dict(sys.modules, modules):
+        sys.modules.pop('uor.async_llm_client', None)
+        sys.modules.pop('uor.llm_client', None)
+        import uor.async_llm_client as alc
+        import uor.llm_client as lc
+        importlib.reload(lc)
+        return importlib.reload(alc)
+
+
+class AsyncLLMClientTest(unittest.TestCase):
+    def test_openai(self):
+        fake_openai = types.ModuleType('openai')
+        chat = mock.AsyncMock()
+        fake_openai.ChatCompletion = mock.MagicMock(acreate=chat)
+        resp = mock.MagicMock()
+        resp.choices = [mock.MagicMock(message=mock.MagicMock(content='ok'))]
+        chat.return_value = resp
+
+        modules = {
+            'openai': fake_openai,
+            'anthropic': types.ModuleType('anthropic'),
+            'google': types.ModuleType('google'),
+            'google.generativeai': mock.MagicMock(),
+        }
+        with mock.patch.dict(os.environ, {'OPENAI_API_KEY': 'k'}):
+            mod = _load_module(modules)
+            result = asyncio.run(mod.async_call_model('openai', 'hi'))
+        self.assertEqual(result, 'ok')
+        fake_openai.ChatCompletion.acreate.assert_called()
+
+    def test_anthropic(self):
+        fake_anthropic = types.ModuleType('anthropic')
+        client_inst = mock.MagicMock()
+        fake_anthropic.AsyncAnthropic = mock.MagicMock(return_value=client_inst)
+        client_inst.messages.create = mock.AsyncMock(return_value=mock.MagicMock(content='anthro'))
+
+        modules = {
+            'openai': types.ModuleType('openai'),
+            'anthropic': fake_anthropic,
+            'google': types.ModuleType('google'),
+            'google.generativeai': mock.MagicMock(),
+        }
+        with mock.patch.dict(os.environ, {'ANTHROPIC_API_KEY': 'k'}):
+            mod = _load_module(modules)
+            result = asyncio.run(mod.async_call_model('anthropic', 'hi'))
+        self.assertEqual(result, 'anthro')
+        client_inst.messages.create.assert_called()
+
+    def test_gemini(self):
+        fake_google = types.ModuleType('google')
+        genai = mock.MagicMock()
+        fake_google.generativeai = genai
+        resp = mock.MagicMock(text='gem')
+        model = mock.MagicMock(generate_content=mock.MagicMock(return_value=resp))
+        genai.GenerativeModel.return_value = model
+
+        modules = {
+            'openai': types.ModuleType('openai'),
+            'anthropic': types.ModuleType('anthropic'),
+            'google': fake_google,
+            'google.generativeai': genai,
+        }
+        with mock.patch.dict(os.environ, {'GOOGLE_API_KEY': 'k'}):
+            mod = _load_module(modules)
+            result = asyncio.run(mod.async_call_model('gemini', 'hi'))
+        self.assertEqual(result, 'gem')
+        model.generate_content.assert_called_with('hi')
+
+    def test_unknown_provider(self):
+        modules = {
+            'openai': types.ModuleType('openai'),
+            'anthropic': types.ModuleType('anthropic'),
+            'google': types.ModuleType('google'),
+            'google.generativeai': mock.MagicMock(),
+        }
+        mod = _load_module(modules)
+        with self.assertRaises(ValueError):
+            asyncio.run(mod.async_call_model('foo', 'hi'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cli_factory.py
+++ b/tests/test_cli_factory.py
@@ -1,0 +1,28 @@
+import io
+import os
+import contextlib
+import importlib.util
+import unittest
+from unittest import mock
+
+spec = importlib.util.spec_from_file_location('uor_cli', os.path.join(os.path.dirname(__file__), '..', 'uor-cli.py'))
+uor_cli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(uor_cli)
+
+
+class CLIFactoryTest(unittest.TestCase):
+    def test_factory_invokes_appfactory(self):
+        async_mock = mock.AsyncMock(return_value='CID')
+        with mock.patch.object(uor_cli, 'AppFactory') as Factory:
+            inst = Factory.return_value
+            inst.build_app = async_mock
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = uor_cli.main(['factory', '--provider', 'openai', 'goal'])
+            self.assertEqual(rc, 0)
+            async_mock.assert_called_with('goal')
+            self.assertEqual(buf.getvalue().strip(), 'CID')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,35 @@
+import asyncio
+import unittest
+from unittest import mock
+
+from uor.agents.factory import AppFactory
+
+
+class AppFactoryTest(unittest.TestCase):
+    def test_build_app(self):
+        planner = mock.AsyncMock()
+        coder = mock.AsyncMock()
+        tester = mock.AsyncMock()
+
+        planner.run.return_value = 'plan'
+        coder.run.return_value = 'code'
+        tester.run.return_value = 'checked'
+
+        factory = AppFactory()
+        factory.planner = planner
+        factory.coder = coder
+        factory.tester = tester
+
+        with mock.patch('assembler.assemble', return_value=[1]), \
+             mock.patch('uor.ipfs_storage.add_data', return_value='CID') as add:
+            cid = asyncio.run(factory.build_app('goal'))
+
+        self.assertEqual(cid, 'CID')
+        planner.run.assert_called_with('goal')
+        coder.run.assert_called_with('plan')
+        tester.run.assert_called_with('code')
+        add.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uor/agents/coder.py
+++ b/uor/agents/coder.py
@@ -1,0 +1,15 @@
+"""Agent that turns a plan into UOR assembly code."""
+from __future__ import annotations
+
+from ..async_llm_client import async_call_model
+
+
+class CoderAgent:
+    """Generate code implementing the planned app."""
+
+    def __init__(self, provider: str = "openai") -> None:
+        self.provider = provider
+
+    async def run(self, plan: str) -> str:
+        prompt = "Write UOR assembly that implements the following plan:\n" + plan
+        return await async_call_model(self.provider, prompt)

--- a/uor/agents/factory.py
+++ b/uor/agents/factory.py
@@ -1,0 +1,26 @@
+"""Orchestrator that coordinates specialized agents to produce an app."""
+from __future__ import annotations
+
+from .planner import PlannerAgent
+from .coder import CoderAgent
+from .tester import TesterAgent
+import assembler
+from .. import ipfs_storage
+
+
+class AppFactory:
+    """Create apps using planner, coder and tester agents."""
+
+    def __init__(self, provider: str = "openai") -> None:
+        self.planner = PlannerAgent(provider)
+        self.coder = CoderAgent(provider)
+        self.tester = TesterAgent(provider)
+
+    async def build_app(self, goal: str) -> str:
+        """Generate an app for ``goal`` and return its IPFS CID."""
+        plan = await self.planner.run(goal)
+        code = await self.coder.run(plan)
+        checked = await self.tester.run(code)
+        chunks_list = assembler.assemble(checked)
+        data = "\n".join(str(x) for x in chunks_list).encode("utf-8")
+        return ipfs_storage.add_data(data)

--- a/uor/agents/planner.py
+++ b/uor/agents/planner.py
@@ -1,0 +1,15 @@
+"""Agent responsible for planning app creation steps."""
+from __future__ import annotations
+
+from ..async_llm_client import async_call_model
+
+
+class PlannerAgent:
+    """Generate a high-level plan for the requested app."""
+
+    def __init__(self, provider: str = "openai") -> None:
+        self.provider = provider
+
+    async def run(self, goal: str) -> str:
+        prompt = f"Create a detailed plan to build an app that {goal}."
+        return await async_call_model(self.provider, prompt)

--- a/uor/agents/tester.py
+++ b/uor/agents/tester.py
@@ -1,0 +1,15 @@
+"""Agent for validating generated assembly code."""
+from __future__ import annotations
+
+from ..async_llm_client import async_call_model
+
+
+class TesterAgent:
+    """Review assembly code and suggest improvements."""
+
+    def __init__(self, provider: str = "openai") -> None:
+        self.provider = provider
+
+    async def run(self, assembly: str) -> str:
+        prompt = "Review this UOR assembly for errors and provide the corrected version:\n" + assembly
+        return await async_call_model(self.provider, prompt)

--- a/uor/async_llm_client.py
+++ b/uor/async_llm_client.py
@@ -1,0 +1,54 @@
+"""Asynchronous helpers for calling LLM providers."""
+from __future__ import annotations
+
+import asyncio
+
+from .llm_client import (
+    openai,
+    anthropic,
+    generativeai,
+    _require,
+    _get_env,
+    MissingDependencyError,
+)
+
+
+async def async_call_model(provider: str, prompt: str) -> str:
+    """Asynchronously send ``prompt`` to ``provider`` and return the response."""
+    provider = provider.lower()
+
+    if provider == "openai":
+        _require(openai, "openai")
+        openai.api_key = _get_env("OPENAI_API_KEY")
+        try:  # pragma: no cover - network errors
+            resp = await openai.ChatCompletion.acreate(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return resp.choices[0].message.content
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError("Failed to call OpenAI") from exc
+
+    if provider == "anthropic":
+        _require(anthropic, "anthropic")
+        try:  # pragma: no cover - network errors
+            client = anthropic.AsyncAnthropic(api_key=_get_env("ANTHROPIC_API_KEY"))
+            resp = await client.messages.create(
+                model="claude-3-opus-20240229",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return getattr(resp, "content", getattr(resp, "completion"))
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError("Failed to call Anthropic") from exc
+
+    if provider in {"gemini", "google"}:
+        _require(generativeai, "google-generativeai")
+        try:  # pragma: no cover - network errors
+            generativeai.configure(api_key=_get_env("GOOGLE_API_KEY"))
+            model = generativeai.GenerativeModel("gemini-pro")
+            resp = await asyncio.to_thread(model.generate_content, prompt)
+            return resp.text
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError("Failed to call Gemini") from exc
+
+    raise ValueError(f"Unknown provider: {provider}")


### PR DESCRIPTION
## Summary
- implement asynchronous LLM client
- implement planner, coder, tester agents and orchestrator
- expose `factory` command in CLI
- update README with async helper and agent factory usage
- add tests for async client, factory orchestrator and CLI

## Testing
- `pytest -q`