### PR TITLE
Add Flask API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,20 @@ python3 uor-cli.py factory "your goal"            # uses OpenAI by default
 ```
 
 Pass `--provider` to select another LLM backend.
+
+## API Server
+
+A small Flask server exposes HTTP endpoints for assembling, running and generating programs.
+Start it with:
+
+```bash
+python3 server.py
+```
+
+Available routes:
+
+- `POST /assemble` – body `{ "text": "..." }` returns `{"chunks": [...]}`
+- `POST /run` – body with `"text"` or `"chunks"` executes the program and returns `{"output": "..."}`
+- `POST /generate` – body `{ "prompt": "...", "provider": "openai" }` calls the selected LLM, assembles the result, stores it via IPFS and returns `{"cid": "..."}`.
+
+The server relies on the same environment variables as `llm_client` for API keys.

--- a/server.py
+++ b/server.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from flask import Flask, jsonify, request
+
+import assembler
+import decoder
+from vm import VM
+from uor import llm_client, ipfs_storage
+
+app = Flask(__name__)
+
+
+@app.post('/assemble')
+def assemble_route():
+    data = request.get_json(force=True)
+    text = data.get('text')
+    if not isinstance(text, str):
+        return jsonify({'error': 'text is required'}), 400
+    program = assembler.assemble(text)
+    return jsonify({'chunks': program})
+
+
+@app.post('/run')
+def run_route():
+    data = request.get_json(force=True)
+    if isinstance(data.get('text'), str):
+        program = assembler.assemble(data['text'])
+    elif isinstance(data.get('chunks'), list):
+        try:
+            program = [int(x) for x in data['chunks']]
+        except Exception:  # pragma: no cover - invalid numbers
+            return jsonify({'error': 'invalid chunks'}), 400
+    else:
+        return jsonify({'error': 'text or chunks required'}), 400
+    vm = VM()
+    output = ''.join(vm.execute(decoder.decode(program)))
+    return jsonify({'output': output})
+
+
+@app.post('/generate')
+def generate_route():
+    data = request.get_json(force=True)
+    prompt = data.get('prompt')
+    if not isinstance(prompt, str):
+        return jsonify({'error': 'prompt is required'}), 400
+    provider = data.get('provider', 'openai')
+    asm = llm_client.call_model(provider, prompt)
+    chunks_list = assembler.assemble(asm)
+    cid = ipfs_storage.add_data('\n'.join(str(x) for x in chunks_list).encode('utf-8'))
+    return jsonify({'cid': cid})
+
+
+def create_app() -> Flask:
+    return app
+
+
+if __name__ == '__main__':
+    app.run()

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest import mock
+import types
+import sys
+
+# Provide minimal Flask stub
+fake_flask = types.ModuleType('flask')
+
+class _Request:
+    json_data = None
+    def get_json(self, force=False):
+        return self.json_data
+
+request = _Request()
+
+class _Response:
+    def __init__(self, json, status=200):
+        self._json = json
+        self.status_code = status
+    def get_json(self):
+        return self._json
+
+def jsonify(obj):
+    return obj
+
+class Flask:
+    def __init__(self, name):
+        self.routes = {}
+    def post(self, path):
+        def decorator(func):
+            self.routes[path] = func
+            return func
+        return decorator
+    def test_client(self):
+        app = self
+        class Client:
+            def post(self, path, json=None):
+                request.json_data = json
+                rv = app.routes[path]()
+                if isinstance(rv, tuple):
+                    data, status = rv
+                else:
+                    data, status = rv, 200
+                if isinstance(data, _Response):
+                    return data
+                return _Response(data, status)
+        return Client()
+
+fake_flask.Flask = Flask
+fake_flask.jsonify = jsonify
+fake_flask.request = request
+sys.modules['flask'] = fake_flask
+
+import assembler
+import importlib
+server = importlib.import_module('server')
+
+
+class APIServerTest(unittest.TestCase):
+    def setUp(self):
+        self.client = server.create_app().test_client()
+
+    def test_assemble(self):
+        asm = "PUSH 1\nPRINT"
+        resp = self.client.post('/assemble', json={'text': asm})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {'chunks': assembler.assemble(asm)})
+
+    def test_run_text(self):
+        asm = "PUSH 2\nPRINT"
+        resp = self.client.post('/run', json={'text': asm})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {'output': '2'})
+
+    def test_run_chunks(self):
+        asm = "PUSH 3\nPRINT"
+        chunks_list = assembler.assemble(asm)
+        resp = self.client.post('/run', json={'chunks': chunks_list})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {'output': '3'})
+
+    def test_generate(self):
+        with mock.patch('uor.llm_client.call_model', return_value='PUSH 1\nPRINT') as call, \
+             mock.patch('uor.ipfs_storage.add_data', return_value='CID') as add:
+            resp = self.client.post('/generate', json={'prompt': 'hi', 'provider': 'openai'})
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.get_json(), {'cid': 'CID'})
+            call.assert_called_with('openai', 'hi')
+            add.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement minimal Flask-based API server
- expose /assemble, /run and /generate endpoints
- document server usage in README
- add unit tests for API server

## Testing
- `python3 -m pytest -q`