### PR TITLE
Add packaging info and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This repository implements a modular "Pure UOR" virtual machine.  Programs are
 encoded as products of prime powers with checksums for integrity.  The VM is
 Turing complete thanks to arithmetic, memory access and branching opcodes.
 
+## Installation
+
+Install the package via `pip` to get the `uor-cli` command:
+
+```bash
+pip install uor-labs
+```
+
+You can then run `uor-cli` from anywhere.
+
 ## Instruction Set
 
 | Instruction | Description               |
@@ -26,18 +36,18 @@ an unbounded dictionary of integer addresses.
 
 ## Assembler and CLI
 
-`uor-cli.py` offers several commands:
+`uor-cli` offers several commands:
 
 ```bash
-python3 uor-cli.py assemble program.asm            # assemble to chunks
-python3 uor-cli.py assemble -o program.uor foo.asm # write chunks to file
-python3 uor-cli.py assemble < foo.asm              # read source from stdin
-python3 uor-cli.py run program.asm                 # assemble and execute
-python3 uor-cli.py run program.uor                 # run pre-encoded program
-python3 uor-cli.py run < program.asm               # assemble from stdin and run
-python3 uor-cli.py ipfs-add program.asm            # store encoded program via IPFS
-python3 uor-cli.py ipfs-run QmCID                  # run program fetched from IPFS
-python3 uor-cli.py generate --provider openai "your prompt"  # create program with an LLM
+uor-cli assemble program.asm            # assemble to chunks
+uor-cli assemble -o program.uor foo.asm # write chunks to file
+uor-cli assemble < foo.asm              # read source from stdin
+uor-cli run program.asm                 # assemble and execute
+uor-cli run program.uor                 # run pre-encoded program
+uor-cli run < program.asm               # assemble from stdin and run
+uor-cli ipfs-add program.asm            # store encoded program via IPFS
+uor-cli ipfs-run QmCID                  # run program fetched from IPFS
+uor-cli generate --provider openai "your prompt"  # create program with an LLM
 ```
 
 Assembly files consist of one instruction per line with optional labels and
@@ -91,7 +101,7 @@ Use `uor.async_llm_client.async_call_model` when coordinating multiple agents co
 Specialized agents (planner, coder and tester) live under `uor.agents`. The `AppFactory` orchestrates them to create new apps and store the result via IPFS. Run this process through the CLI:
 
 ```bash
-python3 uor-cli.py factory "your goal"            # uses OpenAI by default
+uor-cli factory "your goal"            # uses OpenAI by default
 ```
 
 Pass `--provider` to select another LLM backend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "uor-labs"
+version = "0.1.0"
+description = "Pure UOR virtual machine and utilities"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [{name = "UOR Foundation"}]
+requires-python = ">=3.11"
+dependencies = [
+    "ipfshttpclient~=0.8",
+    "openai",
+    "anthropic",
+    "google-generativeai",
+    "flask",
+]
+
+[project.scripts]
+uor-cli = "uor_cli:main"
+
+[tool.setuptools]
+packages = ["uor"]
+py-modules = ["assembler", "chunks", "decoder", "primes", "server", "uor", "vm", "uor_cli"]

--- a/uor_cli.py
+++ b/uor_cli.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Command line interface for the Pure UOR VM.
+
+The tool can assemble text programs into numeric chunks or execute an
+assembly file directly.  If a ``.uor`` file is given, its numbers are
+loaded and executed through the VM.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import inspect
+import sys
+
+from uor import ipfs_storage, llm_client
+from uor.agents.factory import AppFactory
+
+from vm import VM
+from decoder import decode
+import chunks
+import assembler
+
+
+def cmd_assemble(args: argparse.Namespace) -> int:
+    """Assemble a program and optionally write the chunks to a file."""
+    if args.source:
+        with open(args.source, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    else:
+        text = sys.stdin.read()
+
+    program = assembler.assemble(text)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as out:
+            out.write("\n".join(str(ck) for ck in program) + "\n")
+    else:
+        for ck in program:
+            print(ck)
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    """Run a program, assembling it first if needed."""
+    if args.source is None:
+        text = sys.stdin.read()
+        chunks_list = assembler.assemble(text)
+    elif args.source.endswith('.uor'):
+        with open(args.source, 'r', encoding='utf-8') as fh:
+            chunks_list = [int(x) for x in fh.read().split() if x]
+    else:
+        chunks_list = assembler.assemble_file(args.source)
+    vm = VM()
+    output = ''.join(vm.execute(decode(chunks_list)))
+    print(output)
+    return 0
+
+
+def cmd_ipfs_add(args: argparse.Namespace) -> int:
+    """Assemble ``source`` and store the encoded program via IPFS."""
+    if args.source:
+        if args.source.endswith('.uor'):
+            with open(args.source, 'r', encoding='utf-8') as fh:
+                chunks_list = [int(x) for x in fh.read().split() if x]
+        else:
+            chunks_list = assembler.assemble_file(args.source)
+    else:
+        text = sys.stdin.read()
+        chunks_list = assembler.assemble(text)
+    data = '\n'.join(str(x) for x in chunks_list).encode('utf-8')
+    cid = ipfs_storage.add_data(data)
+    print(cid)
+    return 0
+
+
+def cmd_ipfs_run(args: argparse.Namespace) -> int:
+    """Fetch a program by CID from IPFS and execute it."""
+    raw = ipfs_storage.get_data(args.cid)
+    chunks_list = [int(x) for x in raw.decode('utf-8').split() if x]
+    vm = VM()
+    output = ''.join(vm.execute(decode(chunks_list)))
+    print(output)
+    return 0
+
+
+def cmd_generate(args: argparse.Namespace) -> int:
+    """Generate a program via an LLM and store it in IPFS."""
+    asm = llm_client.call_model(args.provider, args.prompt)
+    chunks_list = assembler.assemble(asm)
+    data = '\n'.join(str(x) for x in chunks_list).encode('utf-8')
+    cid = ipfs_storage.add_data(data)
+    print(cid)
+    return 0
+
+
+async def cmd_factory(args: argparse.Namespace) -> int:
+    """Build an app via specialized agents and store it in IPFS."""
+    factory = AppFactory(provider=args.provider)
+    cid = await factory.build_app(args.goal)
+    print(cid)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Pure UOR VM utilities")
+    sub = p.add_subparsers(dest='cmd', required=True)
+
+    pa = sub.add_parser('assemble', help='assemble program')
+    pa.add_argument('source', nargs='?', help='assembly file, defaults to stdin')
+    pa.add_argument('-o', '--output', help='write encoded program to file')
+    pa.set_defaults(func=cmd_assemble)
+
+    pr = sub.add_parser('run', help='assemble and run program')
+    pr.add_argument('source', nargs='?', help='source .asm or encoded .uor file; reads assembly from stdin if omitted')
+    pr.set_defaults(func=cmd_run)
+
+    pi = sub.add_parser('ipfs-add', help='assemble program and store via IPFS')
+    pi.add_argument('source', nargs='?', help='assembly or .uor file, defaults to stdin')
+    pi.set_defaults(func=cmd_ipfs_add)
+
+    px = sub.add_parser('ipfs-run', help='run program from IPFS CID')
+    px.add_argument('cid', help='content identifier to fetch')
+    px.set_defaults(func=cmd_ipfs_run)
+
+    pg = sub.add_parser('generate', help='generate program via an LLM')
+    pg.add_argument('--provider', default='openai',
+                    choices=['openai', 'anthropic', 'gemini'],
+                    help='LLM provider to use')
+    pg.add_argument('prompt', help='prompt describing the program')
+    pg.set_defaults(func=cmd_generate)
+
+    pf = sub.add_parser('factory', help='build app using specialized agents')
+    pf.add_argument('--provider', default='openai',
+                    choices=['openai', 'anthropic', 'gemini'],
+                    help='LLM provider to use')
+    pf.add_argument('goal', help='high level goal for the app')
+    pf.set_defaults(func=cmd_factory)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    result = args.func(args)
+    if inspect.iscoroutine(result):
+        return asyncio.run(result)
+    return result
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+


### PR DESCRIPTION
## Summary
- provide packaging metadata in `pyproject.toml`
- duplicate CLI into `uor_cli.py` for console entry point
- document pip-based installation and update CLI examples to use `uor-cli`

## Testing
- `python3 -m unittest discover -v`