### PR TITLE
Add async server route and IPFS helpers

### DIFF
--- a/server.py
+++ b/server.py
@@ -5,7 +5,7 @@ from flask import Flask, jsonify, request
 import assembler
 import decoder
 from vm import VM
-from uor import llm_client, ipfs_storage
+from uor import async_llm_client, ipfs_storage
 
 app = Flask(__name__)
 
@@ -38,15 +38,16 @@ def run_route():
 
 
 @app.post('/generate')
-def generate_route():
+async def generate_route():
     data = request.get_json(force=True)
     prompt = data.get('prompt')
     if not isinstance(prompt, str):
         return jsonify({'error': 'prompt is required'}), 400
     provider = data.get('provider', 'openai')
-    asm = llm_client.call_model(provider, prompt)
+    asm = await async_llm_client.async_call_model(provider, prompt)
     chunks_list = assembler.assemble(asm)
-    cid = ipfs_storage.add_data('\n'.join(str(x) for x in chunks_list).encode('utf-8'))
+    data_bytes = '\n'.join(str(x) for x in chunks_list).encode('utf-8')
+    cid = await ipfs_storage.async_add_data(data_bytes)
     return jsonify({'cid': cid})
 
 

--- a/tests/test_async_ipfs_storage.py
+++ b/tests/test_async_ipfs_storage.py
@@ -1,0 +1,37 @@
+import importlib
+import sys
+import asyncio
+import unittest
+from unittest import mock
+
+class AsyncIPFSStorageTest(unittest.TestCase):
+    def setUp(self):
+        self.fake_module = mock.MagicMock()
+        self.patcher = mock.patch.dict(sys.modules, {'ipfshttpclient': self.fake_module})
+        self.patcher.start()
+        import uor.ipfs_storage
+        self.mod = importlib.reload(uor.ipfs_storage)
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_async_add_data(self):
+        fake_client = mock.MagicMock()
+        fake_client.__enter__.return_value = fake_client
+        fake_client.add_bytes.return_value = 'CID'
+        self.fake_module.connect.return_value = fake_client
+        cid = asyncio.run(self.mod.async_add_data(b'hello'))
+        fake_client.add_bytes.assert_called_with(b'hello')
+        self.assertEqual(cid, 'CID')
+
+    def test_async_get_data(self):
+        fake_client = mock.MagicMock()
+        fake_client.__enter__.return_value = fake_client
+        fake_client.cat.return_value = b'data'
+        self.fake_module.connect.return_value = fake_client
+        data = asyncio.run(self.mod.async_get_data('CID'))
+        fake_client.cat.assert_called_with('CID')
+        self.assertEqual(data, b'data')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -21,7 +21,7 @@ class AppFactoryTest(unittest.TestCase):
         factory.tester = tester
 
         with mock.patch('assembler.assemble', return_value=[1]), \
-             mock.patch('uor.ipfs_storage.add_data', return_value='CID') as add:
+             mock.patch('uor.ipfs_storage.async_add_data', new=mock.AsyncMock(return_value='CID')) as add:
             cid = asyncio.run(factory.build_app('goal'))
 
         self.assertEqual(cid, 'CID')

--- a/uor/agents/factory.py
+++ b/uor/agents/factory.py
@@ -23,4 +23,4 @@ class AppFactory:
         checked = await self.tester.run(code)
         chunks_list = assembler.assemble(checked)
         data = "\n".join(str(x) for x in chunks_list).encode("utf-8")
-        return ipfs_storage.add_data(data)
+        return await ipfs_storage.async_add_data(data)

--- a/uor/ipfs_storage.py
+++ b/uor/ipfs_storage.py
@@ -1,6 +1,8 @@
 """Utility helpers for storing programs in IPFS."""
 from __future__ import annotations
 
+import asyncio
+
 try:
     import ipfshttpclient  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dependency not installed
@@ -30,3 +32,13 @@ def get_data(cid: str) -> bytes:
             return client.cat(cid)
     except Exception as exc:
         raise RuntimeError("Failed to fetch data from IPFS") from exc
+
+
+async def async_add_data(data: bytes) -> str:
+    """Asynchronously add ``data`` to IPFS and return its CID."""
+    return await asyncio.to_thread(add_data, data)
+
+
+async def async_get_data(cid: str) -> bytes:
+    """Asynchronously retrieve data from IPFS by ``cid``."""
+    return await asyncio.to_thread(get_data, cid)


### PR DESCRIPTION
## Summary
- implement `async_add_data` and `async_get_data` in `ipfs_storage`
- update `AppFactory` to await IPFS writes
- refactor `/generate` route to use async LLM and IPFS calls
- extend test Flask stub to support async endpoints
- add tests for new async IPFS helpers

## Testing
- `pytest -q`