### PR TITLE
Add simple web interface served by Flask

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,13 +1,35 @@
 from __future__ import annotations
 
 from flask import Flask, jsonify, request
+import os
 
 import assembler
 import decoder
 from vm import VM
 from uor import async_llm_client, ipfs_storage
 
+WEB_DIR = os.path.join(os.path.dirname(__file__), 'web')
+
+
+def _load_page(name: str):
+    path = os.path.join(WEB_DIR, name)
+    try:
+        with open(path, 'r', encoding='utf-8') as fh:
+            return fh.read()
+    except OSError:
+        return 'Not Found', 404
+
 app = Flask(__name__)
+
+
+@app.get('/')
+def index_page():
+    return _load_page('index.html')
+
+
+@app.get('/web/<path:page>')
+def web_page(page: str):
+    return _load_page(page)
 
 
 @app.post('/assemble')

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -32,11 +32,30 @@ class Flask:
             self.routes[path] = func
             return func
         return decorator
+    def get(self, path):
+        def decorator(func):
+            self.routes[path] = func
+            return func
+        return decorator
     def test_client(self):
         app = self
         class Client:
             def post(self, path, json=None):
                 request.json_data = json
+                result = app.routes[path]()
+                if asyncio.iscoroutine(result):
+                    rv = asyncio.run(result)
+                else:
+                    rv = result
+                if isinstance(rv, tuple):
+                    data, status = rv
+                else:
+                    data, status = rv, 200
+                if isinstance(data, _Response):
+                    return data
+                return _Response(data, status)
+            def get(self, path):
+                request.json_data = None
                 result = app.routes[path]()
                 if asyncio.iscoroutine(result):
                     rv = asyncio.run(result)

--- a/web/assemble.html
+++ b/web/assemble.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head><title>Assemble</title></head>
+<body>
+<h1>Assemble Program</h1>
+<textarea id="src" rows="10" cols="60"></textarea><br>
+<button id="assemble">Assemble</button>
+<pre id="result"></pre>
+<script>
+document.getElementById('assemble').onclick = async function() {
+    const src = document.getElementById('src').value;
+    const resp = await fetch('/assemble', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({text: src})
+    });
+    const data = await resp.json();
+    document.getElementById('result').textContent = JSON.stringify(data);
+};
+</script>
+</body>
+</html>

--- a/web/generate.html
+++ b/web/generate.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head><title>Generate Program</title></head>
+<body>
+<h1>Generate Program</h1>
+<input id="prompt" size="60"><br>
+<select id="provider">
+  <option value="openai">openai</option>
+  <option value="anthropic">anthropic</option>
+  <option value="google">google</option>
+</select>
+<button id="generate">Generate</button>
+<pre id="result"></pre>
+<script>
+document.getElementById('generate').onclick = async function() {
+    const prompt = document.getElementById('prompt').value;
+    const provider = document.getElementById('provider').value;
+    const resp = await fetch('/generate', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({prompt: prompt, provider: provider})
+    });
+    const data = await resp.json();
+    document.getElementById('result').textContent = JSON.stringify(data);
+};
+</script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><title>UOR Web</title></head>
+<body>
+<h1>UOR Web</h1>
+<ul>
+<li><a href="/web/assemble.html">Assemble</a></li>
+<li><a href="/web/run.html">Run</a></li>
+<li><a href="/web/generate.html">Generate</a></li>
+</ul>
+</body>
+</html>

--- a/web/run.html
+++ b/web/run.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head><title>Run Program</title></head>
+<body>
+<h1>Run Program</h1>
+<textarea id="src" rows="10" cols="60"></textarea><br>
+<button id="run">Run</button>
+<pre id="result"></pre>
+<script>
+document.getElementById('run').onclick = async function() {
+    const src = document.getElementById('src').value;
+    const resp = await fetch('/run', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({text: src})
+    });
+    const data = await resp.json();
+    document.getElementById('result').textContent = JSON.stringify(data);
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML pages with forms for assembling, running and generating programs
- serve static web pages from new `/web` directory
- expand Flask stub in tests for new `get` decorator

## Testing
- `python3 -m pytest -q`