### PR TITLE
Add LLM prompt template utilities

### DIFF
--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,30 @@
+import unittest
+from uor.llm.templates import PromptTemplate, load_template
+
+
+class PromptTemplateTest(unittest.TestCase):
+    def test_add_example_and_render(self):
+        tmpl = PromptTemplate("Hello {name}")
+        tmpl.add_example("Alice", "Hi Alice")
+        text = tmpl.render(name="Bob")
+        self.assertIn("Hello Bob", text)
+        self.assertIn("Input: Alice", text)
+        self.assertIn("Output: Hi Alice", text)
+
+
+class LoaderTest(unittest.TestCase):
+    def test_load_yaml_template(self):
+        tmpl = load_template("sort")
+        result = tmpl.render(algorithm="bubble sort", language="Python")
+        self.assertIn("bubble sort", result)
+        self.assertIn("Python", result)
+
+    def test_load_json_template(self):
+        tmpl = load_template("file_ops.json")
+        result = tmpl.render(action="read", language="Python")
+        self.assertIn("read", result)
+        self.assertIn("Python", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uor/llm/templates.py
+++ b/uor/llm/templates.py
@@ -1,0 +1,80 @@
+"""Prompt templates and loader utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+import json
+
+
+@dataclass
+class PromptTemplate:
+    """Simple prompt template with optional examples."""
+
+    text: str
+    examples: list[dict[str, str]] = field(default_factory=list)
+
+    def add_example(self, input: str, output: str) -> None:
+        """Add an input/output example to the template."""
+        self.examples.append({"input": input, "output": output})
+
+    def render(self, **params: Any) -> str:
+        """Render the template with ``params`` and included examples."""
+        prompt = self.text.format(**params)
+        if self.examples:
+            parts = [prompt, "\nExamples:"]
+            for ex in self.examples:
+                parts.append(f"Input: {ex['input']}\nOutput: {ex['output']}")
+            prompt = "\n".join(parts)
+        return prompt
+
+
+_TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+
+def _load_raw(path: Path) -> dict[str, Any]:
+    if path.suffix in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore
+        except ModuleNotFoundError:  # pragma: no cover - optional
+            with path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _validate_template(data: dict[str, Any]) -> None:
+    if not isinstance(data.get("prompt"), str):
+        raise ValueError("template must contain 'prompt' string")
+    examples = data.get("examples")
+    if examples is None:
+        return
+    if not isinstance(examples, list):
+        raise ValueError("'examples' must be a list")
+    for ex in examples:
+        if not isinstance(ex, dict) or "input" not in ex or "output" not in ex:
+            raise ValueError("each example must have 'input' and 'output'")
+
+
+def load_template(name: str) -> PromptTemplate:
+    """Load a prompt template by ``name`` from the templates directory."""
+    path = Path(name)
+    if not path.suffix:
+        for ext in (".yaml", ".yml", ".json"):
+            cand = _TEMPLATES_DIR / f"{name}{ext}"
+            if cand.exists():
+                path = cand
+                break
+        else:
+            raise FileNotFoundError(f"Template {name!r} not found")
+    else:
+        path = _TEMPLATES_DIR / name
+        if not path.exists():
+            raise FileNotFoundError(f"Template {name!r} not found")
+
+    data = _load_raw(path)
+    _validate_template(data)
+    tmpl = PromptTemplate(data["prompt"], data.get("examples", []))
+    return tmpl

--- a/uor/templates/file_ops.json
+++ b/uor/templates/file_ops.json
@@ -1,0 +1,9 @@
+{
+  "prompt": "Show how to {action} a file in {language}.",
+  "examples": [
+    {
+      "input": "read",
+      "output": "with open('file.txt') as f:\n    data = f.read()"
+    }
+  ]
+}

--- a/uor/templates/sort.yaml
+++ b/uor/templates/sort.yaml
@@ -1,0 +1,9 @@
+{
+  "prompt": "Write a {algorithm} implementation in {language}.",
+  "examples": [
+    {
+      "input": "bubble sort in python",
+      "output": "def bubble_sort(arr):\n    n = len(arr)\n    for i in range(n):\n        for j in range(0, n-i-1):\n            if arr[j] > arr[j+1]:\n                arr[j], arr[j+1] = arr[j+1], arr[j]"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- support simple prompt templates via `uor.llm.templates.PromptTemplate`
- load templates from `uor/templates/`
- add example YAML/JSON templates for sorting and file operations
- test prompt template features

## Testing
- `pytest -q`