### PR TITLE
Add instruction LRU cache and tests

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,38 @@
+import threading
+import unittest
+
+from uor.cache import InstructionCache
+
+
+class InstructionCacheTest(unittest.TestCase):
+    def test_eviction(self):
+        cache = InstructionCache(max_size=2)
+        cache.put(1, 'a')
+        cache.put(2, 'b')
+        cache.get(1)  # mark 1 as recently used
+        cache.put(3, 'c')  # should evict key 2
+        self.assertIsNone(cache.get(2))
+        self.assertEqual(cache.get(1), 'a')
+        self.assertEqual(cache.get(3), 'c')
+
+    def test_thread_safety(self):
+        cache = InstructionCache(max_size=1000)
+
+        def worker(start):
+            for i in range(100):
+                cache.put(start + i, i)
+                self.assertIsNotNone(cache.get(start + i))
+
+        threads = [threading.Thread(target=worker, args=(j * 1000,)) for j in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        stats = cache.get_stats()
+        self.assertEqual(stats['misses'], 0)
+        self.assertEqual(stats['hits'], 5 * 100)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uor/cache.py
+++ b/uor/cache.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from threading import Lock
+from typing import Any, Dict, Optional
+
+
+class InstructionCache:
+    """Thread-safe LRU cache for decoded instructions."""
+
+    def __init__(self, max_size: int = 128) -> None:
+        self.max_size = max_size
+        self._data: "OrderedDict[int, Any]" = OrderedDict()
+        self._lock = Lock()
+        self._hits = 0
+        self._misses = 0
+
+    def get(self, key: int) -> Optional[Any]:
+        """Retrieve ``key`` from the cache."""
+        with self._lock:
+            if key in self._data:
+                value = self._data.pop(key)
+                self._data[key] = value  # mark as recently used
+                self._hits += 1
+                return value
+            self._misses += 1
+            return None
+
+    def put(self, key: int, value: Any) -> None:
+        """Insert ``value`` for ``key`` into the cache."""
+        with self._lock:
+            if key in self._data:
+                self._data.pop(key)
+            elif len(self._data) >= self.max_size:
+                self._data.popitem(last=False)
+            self._data[key] = value
+
+    def clear(self) -> None:
+        """Clear the cache and statistics."""
+        with self._lock:
+            self._data.clear()
+            self._hits = 0
+            self._misses = 0
+
+    def get_stats(self) -> Dict[str, int]:
+        """Return cache statistics as a dictionary."""
+        with self._lock:
+            return {"hits": self._hits, "misses": self._misses}


### PR DESCRIPTION
## Summary
- implement `InstructionCache` with LRU eviction and thread safety
- integrate cache into `decoder._decode_single`
- remove artificial delay in decoder
- add tests for cache eviction and thread safety

## Testing
- `pytest -q`