### PR TITLE
Add advanced VM profiling

### DIFF
--- a/tests/test_profiler_api.py
+++ b/tests/test_profiler_api.py
@@ -1,0 +1,39 @@
+import unittest
+
+import chunks
+from decoder import decode, _CACHE
+from vm import VM
+from uor.profiler import VMProfiler
+
+
+class VMProfilerTest(unittest.TestCase):
+    def test_basic_metrics(self):
+        prog = [
+            chunks.chunk_push(7),
+            chunks.chunk_store(0),
+            chunks.chunk_load(0),
+            chunks.chunk_print(),
+        ]
+        _CACHE.clear()
+        profiler = VMProfiler()
+        vm = VM(profiler=profiler)
+        out = ''.join(vm.execute(decode(prog)))
+        self.assertEqual(out, '7')
+        metrics = profiler.metrics()
+        self.assertEqual(metrics['instruction_count'], len(prog))
+        self.assertEqual(metrics['memory_access'][0]['write'], 1)
+        self.assertEqual(metrics['memory_access'][0]['read'], 1)
+        self.assertIn('cache_stats', metrics)
+
+    def test_flamegraph_export(self):
+        _CACHE.clear()
+        prog = [chunks.chunk_push(1), chunks.chunk_print()]
+        profiler = VMProfiler()
+        vm = VM(profiler=profiler)
+        list(vm.execute(decode(prog)))
+        flame = profiler.export_flamegraph()
+        self.assertTrue(flame.strip().startswith('ip_'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uor/profiler.py
+++ b/uor/profiler.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Advanced profiler for the UOR virtual machine."""
+
+import json
+import time
+from collections import defaultdict
+from typing import Any, Dict, Optional
+
+from decoder import _CACHE
+
+
+class VMProfiler:
+    """Collect detailed execution metrics for a VM run."""
+
+    def __init__(self) -> None:
+        self.reset()
+
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        self.start_time = time.perf_counter()
+        self.instruction_count = 0
+        self.total_time = 0.0
+        self.opcode_counts: Dict[int, int] = defaultdict(int)
+        self.ip_counts: Dict[int, int] = defaultdict(int)
+        self.instruction_times: Dict[int, float] = defaultdict(float)
+        self.memory_access: Dict[int, Dict[str, int]] = defaultdict(lambda: {"read": 0, "write": 0})
+        self.cache_hits = 0
+        self.cache_misses = 0
+
+    # ------------------------------------------------------------------
+    def record_instruction(self, ip: int, opcode: Optional[int], duration: float, *, cache_hit: bool = False) -> None:
+        """Record execution of a single instruction."""
+        self.instruction_count += 1
+        self.total_time += duration
+        if opcode is not None:
+            self.opcode_counts[opcode] += 1
+        self.ip_counts[ip] += 1
+        self.instruction_times[ip] += duration
+        if cache_hit:
+            self.cache_hits += 1
+
+    def record_memory_access(self, addr: int, mode: str) -> None:
+        if mode == "read":
+            self.memory_access[addr]["read"] += 1
+        elif mode == "write":
+            self.memory_access[addr]["write"] += 1
+
+    # ------------------------------------------------------------------
+    def metrics(self) -> Dict[str, Any]:
+        elapsed = time.perf_counter() - self.start_time
+        cache_stats = _CACHE.get_stats()
+        return {
+            "instruction_count": self.instruction_count,
+            "elapsed": elapsed,
+            "opcode_counts": dict(self.opcode_counts),
+            "ip_hotspots": dict(self.ip_counts),
+            "memory_access": dict(self.memory_access),
+            "cache_stats": {
+                "hits": cache_stats.get("hits", 0) + self.cache_hits,
+                "misses": cache_stats.get("misses", 0),
+            },
+        }
+
+    def export_report(self) -> str:
+        """Return collected metrics as a JSON string."""
+        return json.dumps(self.metrics())
+
+    def export_flamegraph(self) -> str:
+        """Return execution timing data in folded stack format."""
+        lines = []
+        for ip, dur in self.instruction_times.items():
+            lines.append(f"ip_{ip} {dur}\n")
+        return "".join(lines)
+


### PR DESCRIPTION
## Summary
- implement `VMProfiler` for detailed execution metrics
- integrate profiler hooks in `VM.execute`
- record memory accesses for LOAD/STORE
- export metrics and flamegraph data
- add unit tests for profiler

## Testing
- `python3 -m unittest discover -v`