### PR TITLE
Add cache statistics

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -14,6 +14,12 @@ class InstructionCacheTest(unittest.TestCase):
         self.assertIsNone(cache.get(2))
         self.assertEqual(cache.get(1), 'a')
         self.assertEqual(cache.get(3), 'c')
+        stats = cache.get_stats()
+        self.assertEqual(stats['size'], 2)
+        self.assertEqual(stats['hits'], 3)
+        self.assertEqual(stats['misses'], 1)
+        self.assertAlmostEqual(stats['hit_rate'], 0.75)
+        self.assertEqual(stats['avg_decode_time_saved'], 0.0)
 
     def test_thread_safety(self):
         cache = InstructionCache(max_size=1000)
@@ -32,6 +38,23 @@ class InstructionCacheTest(unittest.TestCase):
         stats = cache.get_stats()
         self.assertEqual(stats['misses'], 0)
         self.assertEqual(stats['hits'], 5 * 100)
+        self.assertEqual(stats['size'], 5 * 100)
+        self.assertEqual(stats['hit_rate'], 1.0)
+        self.assertEqual(stats['avg_decode_time_saved'], 0.0)
+
+    def test_time_saved_metric(self):
+        cache = InstructionCache(max_size=2)
+        cache.put(1, 'a', decode_time=1.0)
+        cache.put(2, 'b', decode_time=0.5)
+        self.assertEqual(cache.get(1), 'a')
+        self.assertEqual(cache.get(2), 'b')
+
+        stats = cache.get_stats()
+        self.assertEqual(stats['hits'], 2)
+        self.assertEqual(stats['misses'], 0)
+        self.assertEqual(stats['size'], 2)
+        self.assertEqual(stats['hit_rate'], 1.0)
+        self.assertAlmostEqual(stats['avg_decode_time_saved'], 0.75)
 
 
 if __name__ == '__main__':

--- a/uor/cache.py
+++ b/uor/cache.py
@@ -14,6 +14,9 @@ class InstructionCache:
         self._lock = Lock()
         self._hits = 0
         self._misses = 0
+        self._decode_times: Dict[int, float] = {}
+        self._total_time_saved = 0.0
+        self._time_saved_hits = 0
 
     def get(self, key: int) -> Optional[Any]:
         """Retrieve ``key`` from the cache."""
@@ -22,27 +25,53 @@ class InstructionCache:
                 value = self._data.pop(key)
                 self._data[key] = value  # mark as recently used
                 self._hits += 1
+                if key in self._decode_times:
+                    self._total_time_saved += self._decode_times[key]
+                    self._time_saved_hits += 1
                 return value
             self._misses += 1
             return None
 
-    def put(self, key: int, value: Any) -> None:
-        """Insert ``value`` for ``key`` into the cache."""
+    def put(self, key: int, value: Any, *, decode_time: Optional[float] = None) -> None:
+        """Insert ``value`` for ``key`` into the cache.
+
+        If ``decode_time`` is provided it is used when calculating the average
+        decode time saved for cache hits.
+        """
         with self._lock:
             if key in self._data:
                 self._data.pop(key)
             elif len(self._data) >= self.max_size:
-                self._data.popitem(last=False)
+                old_key, _ = self._data.popitem(last=False)
+                self._decode_times.pop(old_key, None)
             self._data[key] = value
+            if decode_time is not None:
+                self._decode_times[key] = decode_time
 
     def clear(self) -> None:
         """Clear the cache and statistics."""
         with self._lock:
             self._data.clear()
+            self._decode_times.clear()
             self._hits = 0
             self._misses = 0
+            self._total_time_saved = 0.0
+            self._time_saved_hits = 0
 
-    def get_stats(self) -> Dict[str, int]:
+    def get_stats(self) -> Dict[str, float]:
         """Return cache statistics as a dictionary."""
         with self._lock:
-            return {"hits": self._hits, "misses": self._misses}
+            ops = self._hits + self._misses
+            hit_rate = self._hits / ops if ops else 0.0
+            avg_time = (
+                self._total_time_saved / self._time_saved_hits
+                if self._time_saved_hits
+                else 0.0
+            )
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "size": len(self._data),
+                "hit_rate": hit_rate,
+                "avg_decode_time_saved": avg_time,
+            }


### PR DESCRIPTION
## Summary
- compute hit rate, current size, and avg decode time saved in `InstructionCache`
- expose the metrics via `get_stats`
- update cache tests for new metrics

## Testing
- `pytest -q`