### PR TITLE
Add VM error handling for stack underflow and segfault

### DIFF
--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -9,6 +9,8 @@ from uor.exceptions import (
     MemoryAccessError,
     InvalidOpcodeError,
     StackOverflowError,
+    StackUnderflowError,
+    SegmentationFaultError,
 )
 
 
@@ -71,6 +73,18 @@ class VMTest(unittest.TestCase):
                 list(VM().execute(decode(prog)))
         finally:
             SegmentedMemory.STACK_SIZE = old
+
+    def test_stack_underflow(self):
+        prog = [chunks.chunk_add()]
+        with self.assertRaises(StackUnderflowError) as cm:
+            list(VM().execute(decode(prog)))
+        self.assertEqual(cm.exception.ip, 0)
+
+    def test_segmentation_fault(self):
+        prog = [chunks.chunk_jmp(-2)]
+        with self.assertRaises(SegmentationFaultError) as cm:
+            list(VM().execute(decode(prog)))
+        self.assertEqual(cm.exception.ip, -1)
 
 
 if __name__ == '__main__':

--- a/uor/exceptions.py
+++ b/uor/exceptions.py
@@ -23,3 +23,9 @@ class InvalidOpcodeError(UORException):
 
 class ChecksumError(UORException):
     """Raised when an instruction checksum is invalid."""
+
+class StackUnderflowError(UORException):
+    """Raised when popping from an empty stack."""
+
+class SegmentationFaultError(UORException):
+    """Raised when the instruction pointer becomes invalid."""


### PR DESCRIPTION
## Summary
- extend `uor.exceptions` with `StackUnderflowError` and `SegmentationFaultError`
- enhance `VM` to check for underflow and invalid instruction pointers
- update VM operations to use new helper pop methods
- add unit tests for the new exceptions

## Testing
- `pytest -q`