### PR TITLE
Add DEBUG and ATOMIC instructions

### DIFF
--- a/assembler.py
+++ b/assembler.py
@@ -88,6 +88,10 @@ def assemble(text: str) -> List[int]:
             result.append(chunks.chunk_brk())
         elif op == "TRACE":
             result.append(chunks.chunk_trace())
+        elif op == "DEBUG":
+            result.append(chunks.chunk_debug())
+        elif op == "ATOMIC":
+            result.append(chunks.chunk_atomic())
         elif op == "PRINT":
             result.append(chunks.chunk_print())
         elif op == "LOAD":

--- a/chunks.py
+++ b/chunks.py
@@ -9,7 +9,7 @@ from primes import get_prime, _PRIME_IDX
 from primes import _PRIMES
 from primes import _extend_primes_to
 
-_extend_primes_to(52)
+_extend_primes_to(54)
 OP_PUSH, OP_ADD, OP_PRINT = _PRIMES[0], _PRIMES[1], _PRIMES[2]
 OP_SUB, OP_MUL = _PRIMES[6], _PRIMES[7]
 OP_LOAD, OP_STORE = _PRIMES[8], _PRIMES[9]
@@ -31,6 +31,7 @@ OP_SYSCALL, OP_INT, OP_HALT = _PRIMES[43], _PRIMES[44], _PRIMES[45]
 OP_NOP, OP_HASH, OP_SIGN = _PRIMES[46], _PRIMES[47], _PRIMES[48]
 OP_VERIFY, OP_RNG, OP_BRK = _PRIMES[49], _PRIMES[50], _PRIMES[51]
 OP_TRACE = _PRIMES[52]
+OP_DEBUG, OP_ATOMIC = _PRIMES[53], _PRIMES[54]
 BLOCK_TAG, NTT_TAG, T_MOD = _PRIMES[3], _PRIMES[4], _PRIMES[5]
 NTT_ROOT = 2
 
@@ -306,3 +307,11 @@ def chunk_brk() -> int:
 
 def chunk_trace() -> int:
     return _attach_checksum(OP_TRACE ** 4, [(OP_TRACE, 4)])
+
+
+def chunk_debug() -> int:
+    return _attach_checksum(OP_DEBUG ** 4, [(OP_DEBUG, 4)])
+
+
+def chunk_atomic() -> int:
+    return _attach_checksum(OP_ATOMIC ** 4, [(OP_ATOMIC, 4)])

--- a/tests/test_debug_atomic.py
+++ b/tests/test_debug_atomic.py
@@ -1,0 +1,38 @@
+import unittest
+import assembler
+from decoder import decode
+from vm import VM
+
+
+class DebugAtomicInstructionsTest(unittest.TestCase):
+    def run_prog(self, text: str, vm: VM | None = None) -> tuple[str, VM]:
+        prog = assembler.assemble(text)
+        vm = vm or VM()
+        out = ''.join(vm.execute(decode(prog)))
+        return out, vm
+
+    def test_debug_output(self):
+        src = """
+        DEBUG
+        PUSH 1
+        PRINT
+        """
+        out, _ = self.run_prog(src)
+        self.assertEqual(out, 'DEBUG1')
+
+    def test_atomic_toggle(self):
+        src = """
+        ATOMIC
+        ATOMIC
+        """
+        vm = VM()
+        out, vm = self.run_prog(src, vm)
+        self.assertEqual(out, '')
+        self.assertFalse(vm.atomic)
+        out2, vm2 = self.run_prog("ATOMIC")
+        self.assertEqual(out2, '')
+        self.assertTrue(vm2.atomic)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vm.py
+++ b/vm.py
@@ -33,7 +33,7 @@ from chunks import (
     OP_DIV, OP_MOD, OP_AND, OP_OR, OP_XOR, OP_SHL, OP_SHR, OP_NEG,
     OP_FMUL, OP_FDIV, OP_F2I, OP_I2F,
     OP_SYSCALL, OP_INT, OP_HALT, OP_NOP,
-    OP_HASH, OP_SIGN, OP_VERIFY, OP_RNG, OP_BRK, OP_TRACE,
+    OP_HASH, OP_SIGN, OP_VERIFY, OP_RNG, OP_BRK, OP_TRACE, OP_DEBUG, OP_ATOMIC,
     NEG_FLAG,
     BLOCK_TAG, NTT_TAG, T_MOD,
     NTT_ROOT,
@@ -48,6 +48,7 @@ class VM:
         self.call_stack: List[int] = []
         self.io_in: List[int] = []
         self.io_out: List[int] = []
+        self.atomic: bool = False
         self._counter: Dict[int, int] = {}
         self._compiled: Dict[int, JITBlock] = {}
         self.jit_threshold: int = 100
@@ -95,6 +96,8 @@ class VM:
             OP_RNG: self._op_rng,
             OP_BRK: self._op_brk,
             OP_TRACE: self._op_trace,
+            OP_DEBUG: self._op_debug,
+            OP_ATOMIC: self._op_atomic,
             OP_INPUT: self._op_input,
             OP_OUTPUT: self._op_output,
             OP_NET_SEND: self._op_net_send,
@@ -493,4 +496,11 @@ class VM:
 
     def _op_trace(self, data: List[Tuple[int, int]]) -> Iterator[str]:
         yield str(self.stack[-1] if self.stack else 0)
+
+    def _op_debug(self, data: List[Tuple[int, int]]) -> Iterator[str]:
+        yield "DEBUG"
+
+    def _op_atomic(self, data: List[Tuple[int, int]]) -> Iterator[str]:
+        self.atomic = not self.atomic
+        return iter(())
 


### PR DESCRIPTION
## Summary
- extend opcode set with OP_DEBUG and OP_ATOMIC
- implement chunk helpers for debug and atomic
- support new instructions in assembler and VM
- add simple semantics for _op_debug and _op_atomic
- test the new instructions

## Testing
- `pytest -q`