### PR TITLE
Introduce JIT compilation cache

### DIFF
--- a/tests/test_jit_cache.py
+++ b/tests/test_jit_cache.py
@@ -1,0 +1,20 @@
+import chunks
+from decoder import decode
+from vm import VM
+
+
+def test_jit_cache_ttl():
+    prog = decode([chunks.chunk_push(1), chunks.chunk_print()])
+    vm = VM()
+    vm._jit.available = True
+    vm.jit_threshold = 1
+    vm._jit.ttl = 0.0
+    list(vm.execute(prog))
+    first = vm._compiled.get(0)
+    assert first is not None
+    list(vm.execute(prog))
+    second = vm._compiled.get(0)
+    assert second is not None
+    assert second is not first
+    assert vm._jit.blocks_compiled >= 2
+

--- a/uor/jit/compiler.py
+++ b/uor/jit/compiler.py
@@ -1,19 +1,24 @@
-"""JIT compiler infrastructure for the Pure UOR VM."""
 from __future__ import annotations
 
+import ctypes
+import os
 import platform
-from typing import Callable, Iterable, List
-
-try:
-    import llvmlite.ir as ir  # type: ignore
-    import llvmlite.binding as llvm  # type: ignore
-    _HAS_LLVM = True
-except Exception:  # pragma: no cover - optional dependency
-    ir = None  # type: ignore
-    llvm = None  # type: ignore
-    _HAS_LLVM = False
+import subprocess
+import tempfile
+import time
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from decoder import DecodedInstruction
+from primes import _PRIME_IDX
+from chunks import (
+    OP_PUSH,
+    OP_ADD,
+    OP_SUB,
+    OP_MUL,
+    OP_DIV,
+    OP_MOD,
+    OP_NEG,
+)
 
 
 class JITBlock:
@@ -28,29 +33,45 @@ class JITBlock:
 
 
 class JITCompiler:
-    """Very small JIT compiler using llvmlite when available."""
+    """JIT compiler using a tiny C backend with caching."""
 
-    def __init__(self) -> None:
+    def __init__(self, ttl: float = 60.0) -> None:
         self.arch = platform.machine().lower()
-        self.available = _HAS_LLVM and self.arch in {"x86_64", "amd64", "aarch64", "arm64"}
-        if self.available:
-            llvm.initialize()
-            llvm.initialize_native_target()
-            llvm.initialize_native_asmprinter()
+        self.available = self.arch in {"x86_64", "amd64", "aarch64", "arm64"}
+        self.ttl = ttl
+        self._cache: Dict[Tuple[Tuple[Tuple[int, int], ...], ...], Tuple[JITBlock, float]] = {}
+        self.blocks_compiled = 0
+        self.cache_hits = 0
+        self.cache_misses = 0
+        self.trace: Dict[int, int] = {}
 
     # ------------------------------------------------------------------
-    def compile_block(self, instructions: List[DecodedInstruction]) -> JITBlock | None:
-        """Compile a block of decoded instructions."""
-        if not self.available:
-            return self._compile_py(instructions)
-        try:
-            return self._compile_llvm(instructions)
-        except Exception:  # pragma: no cover - LLVM may fail
-            return self._compile_py(instructions)
+    def compile_block(self, instructions: List[DecodedInstruction]) -> Optional[JITBlock]:
+        """Compile ``instructions`` and return a ``JITBlock``."""
+        key = tuple(tuple(instr.data) for instr in instructions)
+        self._prune()
+        entry = self._cache.get(key)
+        if entry is not None:
+            self.cache_hits += 1
+            return entry[0]
+        self.cache_misses += 1
+        block = self._compile_native(instructions) if self.available else None
+        if block is None:
+            block = self._compile_py(instructions)
+        self._cache[key] = (block, time.time() + self.ttl)
+        self.blocks_compiled += 1
+        return block
+
+    # ------------------------------------------------------------------
+    def _prune(self) -> None:
+        now = time.time()
+        for k, (_, exp) in list(self._cache.items()):
+            if exp < now:
+                self._cache.pop(k, None)
 
     # ------------------------------------------------------------------
     def _compile_py(self, instructions: List[DecodedInstruction]) -> JITBlock:
-        """Fallback compilation to pure Python code."""
+        """Fallback: execute instructions via regular handlers."""
 
         def block(vm: "VM") -> Iterable[str]:
             for instr in instructions:
@@ -63,36 +84,72 @@ class JITCompiler:
         return JITBlock(block, end_ip=0)
 
     # ------------------------------------------------------------------
-    def _compile_llvm(self, instructions: List[DecodedInstruction]) -> JITBlock:
-        """Compile to native code via llvmlite."""
-        # This is a very small and limited example.  We build a function
-        # that simply dispatches back to the Python opcode handlers.
-        # In a full implementation we would translate the bytecode to
-        # real machine operations.  Here we keep it minimal but still
-        # produce an executable LLVM function when llvmlite is available.
-        module = ir.Module(name="jit")
-        func_ty = ir.FunctionType(ir.VoidType(), [ir.IntType(64).as_pointer()])
-        func = ir.Function(module, func_ty, name="jit_block")
-        block = func.append_basic_block(name="entry")
-        builder = ir.IRBuilder(block)
-        builder.ret_void()
+    def _compile_native(self, instructions: List[DecodedInstruction]) -> Optional[JITBlock]:
+        supported = {OP_PUSH, OP_ADD, OP_SUB, OP_MUL, OP_DIV, OP_MOD, OP_NEG}
+        lines: List[str] = []
+        for instr in instructions:
+            op = next((p for p, e in instr.data if e == 4), None)
+            if op not in supported:
+                return None
+            if op == OP_PUSH:
+                vp = next(p for p, e in instr.data if e == 5)
+                val = _PRIME_IDX[vp]
+                lines.append(f"stack[++sp] = {val};")
+            elif op == OP_ADD:
+                lines.append("sp--; stack[sp] = stack[sp] + stack[sp+1];")
+            elif op == OP_SUB:
+                lines.append("sp--; stack[sp] = stack[sp] - stack[sp+1];")
+            elif op == OP_MUL:
+                lines.append("sp--; stack[sp] = stack[sp] * stack[sp+1];")
+            elif op == OP_DIV:
+                lines.append("sp--; if(stack[sp+1]==0) return; stack[sp]=stack[sp]/stack[sp+1];")
+            elif op == OP_MOD:
+                lines.append("sp--; if(stack[sp+1]==0) return; stack[sp]=stack[sp]%stack[sp+1];")
+            elif op == OP_NEG:
+                lines.append("stack[sp] = -stack[sp];")
 
-        llvm_module = llvm.parse_assembly(str(module))
-        llvm_module.verify()
-        target = llvm.Target.from_default_triple()
-        target_machine = target.create_target_machine()
-        with llvm.create_mcjit_compiler(llvm_module, target_machine) as ee:
-            ee.finalize_object()
-            ptr = ee.get_function_address("jit_block")
+        c_src = "\n".join(
+            [
+                "#include <stdint.h>",
+                "void block(long *stack, long *sp_ptr){",
+                "    long sp = *sp_ptr;",
+                *(f"    {ln}" for ln in lines),
+                "    *sp_ptr = sp;",
+                "}",
+            ]
+        )
 
-            import ctypes
+        td = tempfile.mkdtemp()
+        c_file = os.path.join(td, "block.c")
+        so_file = os.path.join(td, "block.so")
+        with open(c_file, "w") as f:
+            f.write(c_src)
+        try:
+            subprocess.run([
+                "gcc",
+                "-shared",
+                "-O2",
+                "-fPIC",
+                c_file,
+                "-o",
+                so_file,
+            ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except Exception:
+            return None
+        lib = ctypes.CDLL(so_file)
+        func = lib.block
+        func.argtypes = [ctypes.POINTER(ctypes.c_long), ctypes.POINTER(ctypes.c_long)]
+        func.restype = None
 
-            cfunc = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(ptr)
+        def block(vm: "VM") -> Iterable[str]:  # pragma: no cover - runtime
+            size = len(vm.stack) + 32
+            arr_type = ctypes.c_long * size
+            arr = arr_type(*vm.stack, *([0] * (size - len(vm.stack))))
+            sp = ctypes.c_long(len(vm.stack) - 1)
+            func(arr, ctypes.byref(sp))
+            vm.stack = list(arr)[: sp.value + 1]
+            vm.ip += len(instructions)
+            return iter(())
 
-            def block(vm: "VM") -> Iterable[str]:  # pragma: no cover - runtime
-                cfunc(id(vm))
-                vm.ip += len(instructions)
-                return iter(())
-
-            return JITBlock(block, end_ip=0)
+        return JITBlock(block, end_ip=0)
 


### PR DESCRIPTION
## Summary
- implement a new JIT compiler that emits native C code with `ctypes`
- add a TTL based cache for compiled blocks
- update `VM` and `DebugVM` to track expiration and use the cache
- raise the default hot path threshold to 1000
- test cache expiry behaviour

## Testing
- `pytest -q`
