### PR TITLE
Implement canonical prime addressing

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ pip install -r requirements.txt
 ipfs daemon &
 ```
 
+### Canonical Addressing
+
+`uor.addressing` introduces a canonical storage system based on 512‑bit prime
+digests. Objects are hashed with SHA‑512 and mapped to the nearest prime to
+create deterministic addresses. A lightweight distributed hash table manages the
+mapping from addresses to IPFS CIDs while providing an LRU cache for frequent
+lookups. Namespaces like `org.uor.stdlib.math` resolve to their canonical
+address so different VMs can reference and retrieve identical objects.
+
+See `examples/canonical_demo.py` for a short example.
+
 ## LLM API Keys
 
 The upcoming LLM helpers require API credentials. Set the following environment

--- a/examples/canonical_demo.py
+++ b/examples/canonical_demo.py
@@ -1,0 +1,12 @@
+from uor.addressing import DHT
+
+# Simulate storing and retrieving a VM program
+PROGRAM = b"PUSH 1\nPUSH 2\nADD\nPRINT"
+
+dht = DHT()
+
+addr = dht.store("org.uor.stdlib.math", PROGRAM)
+print("Stored program at", addr)
+
+retrieved = dht.retrieve(addr)
+print("Retrieved:\n", retrieved.decode())

--- a/tests/test_canonical_address.py
+++ b/tests/test_canonical_address.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+import unittest
+from unittest import mock
+
+from uor.addressing import canonical_address, DHT
+import primes
+
+class CanonicalAddressTest(unittest.TestCase):
+    def setUp(self):
+        # fake ipfshttpclient module
+        self.fake_ipfs = mock.MagicMock()
+        self.patcher = mock.patch.dict(sys.modules, {'ipfshttpclient': self.fake_ipfs})
+        self.patcher.start()
+        import uor.ipfs_storage as ipfs_storage
+        importlib.reload(ipfs_storage)
+        self.ipfs = ipfs_storage
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_canonical_prime(self):
+        data = b'hello world'
+        addr = canonical_address(data)
+        self.assertTrue(primes.miller_rabin(addr))
+
+    def test_store_and_retrieve(self):
+        dht = DHT(nodes=2, cache_size=2)
+        # mock ipfs add/get
+        self.fake_ipfs.connect.return_value.__enter__.return_value = self.fake_ipfs
+        self.fake_ipfs.add_bytes.return_value = 'CID'
+        self.fake_ipfs.cat.return_value = b'hello'
+        addr = dht.store('org.uor.test', b'hello')
+        out = dht.retrieve(addr)
+        self.assertEqual(out, b'hello')
+        # cached retrieval should not call IPFS again
+        self.fake_ipfs.cat.reset_mock()
+        out2 = dht.retrieve(addr)
+        self.assertEqual(out2, b'hello')
+        self.fake_ipfs.cat.assert_not_called()
+        self.assertEqual(dht.resolve('org.uor.test'), addr)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uor/addressing.py
+++ b/uor/addressing.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Canonical addressing utilities based on 512-bit prime digests."""
+
+import hashlib
+from typing import Dict, Optional
+
+from . import ipfs_storage
+from .cache import InstructionCache
+import primes
+
+
+def _nearest_prime(n: int) -> int:
+    """Return the smallest prime >= ``n`` using Miller-Rabin."""
+    if n % 2 == 0:
+        n += 1
+    while True:
+        if primes.miller_rabin(n):
+            return n
+        n += 2
+
+
+def canonical_address(data: bytes) -> int:
+    """Return a 512-bit prime digest for ``data``."""
+    digest = hashlib.sha512(data).digest()
+    num = int.from_bytes(digest, "big")
+    return _nearest_prime(num)
+
+
+class DHT:
+    """Simple distributed hash table mapping addresses to IPFS CIDs."""
+
+    def __init__(self, nodes: int = 3, cache_size: int = 64) -> None:
+        self.tables = [{} for _ in range(max(1, nodes))]
+        self.cache = InstructionCache(max_size=cache_size)
+        self.namespaces: Dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Node selection helpers
+    # ------------------------------------------------------------------
+    def _select_table(self, addr: int) -> Dict[int, Dict[str, str]]:
+        return self.tables[addr % len(self.tables)]
+
+    # ------------------------------------------------------------------
+    # Store and retrieve
+    # ------------------------------------------------------------------
+    def store(self, namespace: str, data: bytes) -> int:
+        addr = canonical_address(data)
+        cid = ipfs_storage.add_data(data)
+        table = self._select_table(addr)
+        existing = table.get(addr)
+        if existing and existing.get("cid") != cid:
+            # collision, search next free prime
+            next_addr = _nearest_prime(addr + 2)
+            addr = next_addr
+            table = self._select_table(addr)
+        table[addr] = {"namespace": namespace, "cid": cid}
+        self.namespaces[namespace] = addr
+        self.cache.put(addr, data)
+        return addr
+
+    def retrieve(self, addr: int) -> bytes:
+        cached = self.cache.get(addr)
+        if cached is not None:
+            return cached
+        table = self._select_table(addr)
+        entry = table.get(addr)
+        if not entry:
+            raise KeyError("Address not found")
+        data = ipfs_storage.get_data(entry["cid"])
+        self.cache.put(addr, data)
+        return data
+
+    def resolve(self, namespace: str) -> Optional[int]:
+        return self.namespaces.get(namespace)


### PR DESCRIPTION
## Summary
- introduce `addressing` module with SHA-512 prime digests and DHT
- document canonical addressing in README
- add example showing storage and retrieval via canonical addresses
- add unit tests for the new system

## Testing
- `python3 -m pytest -q`
