### PR TITLE
Add UOR-Script standard library modules

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,3 +6,4 @@ Welcome to uor-labs's documentation!
    :caption: Contents:
 
    usage
+   stdlib

--- a/docs/stdlib.rst
+++ b/docs/stdlib.rst
@@ -1,0 +1,26 @@
+UOR-Script Standard Library
+===========================
+
+The standard library provides common utilities implemented in UOR-Script and
+assembly.  Modules are stored under ``uor/stdlib`` and can be used by the
+compiler or referenced directly by their canonical address when running inside
+the VM.
+
+Modules
+-------
+
+* ``math.uors`` – arithmetic helpers and number theory functions
+* ``math_advanced.asm`` – VM primitives for trigonometry and other heavy
+actions
+* ``io.uors`` – console and file I/O abstractions
+* ``io_primitives.asm`` – assembly helpers for I/O and networking
+* ``collections.uors`` – coherent list, map and set implementations
+* ``iterator.asm`` – basic iterator protocol
+* ``crypto.uors`` – hashing and signature helpers
+* ``crypto_primitives.asm`` – cryptographic VM primitives
+* ``memory.asm`` – memory management utilities
+* ``loader.asm`` – module loading and caching logic
+* ``test.uors`` – minimal testing helpers
+
+Examples are provided in ``examples/stdlib_examples.uors`` showcasing basic
+usage of the library objects.

--- a/examples/stdlib_examples.uors
+++ b/examples/stdlib_examples.uors
@@ -1,0 +1,67 @@
+// Demonstration of standard library usage
+
+// Calculate factorial with coherence
+function testMath() -> void {
+    let m = Math();
+    let result = m.factorial(5);
+    IO.println(result);  // Output: 120
+    
+    let g = m.gcd(48, 18);
+    IO.println(g);  // Output: 6
+    
+    let s = m.sqrt(144);
+    IO.println(s);  // Output: 12
+}
+
+// Using coherent list
+function testList() -> void {
+    let list = CoherentList.new();
+    
+    list.push(10);
+    list.push(20);
+    list.push(30);
+    
+    let value = list.pop();
+    IO.println(value);  // Output: 30
+    
+    list.set(0, 100);
+    let first = list.get(0);
+    IO.println(first);  // Output: 100
+}
+
+// Cryptographic operations
+function testCrypto() -> void {
+    let c = Crypto();
+    
+    // Generate key pair
+    let keys = c.generateKeyPair();
+    let privateKey = load(keys);
+    let publicKey = load(keys + 1);
+    
+    // Sign data
+    let data = 42;
+    let signature = c.sign(data, privateKey);
+    
+    // Verify signature
+    let valid = c.verify(data, signature, publicKey);
+    if (valid) {
+        IO.println(1);  // Success
+    }
+}
+
+// File operations
+function testIO() -> void {
+    let io = IO();
+    
+    // Read user input
+    let value = io.read();
+    
+    // Process and output
+    let result = value * 2;
+    io.println(result);
+    
+    // File operations (hypothetical)
+    let file = io.fileOpen(12345);  // filename as number
+    io.fileWrite(file, result, 1);
+    io.fileClose(file);
+}

--- a/uor/stdlib/__init__.py
+++ b/uor/stdlib/__init__.py
@@ -1,0 +1,1 @@
+"""UOR-Script standard library modules."""

--- a/uor/stdlib/collections.uors
+++ b/uor/stdlib/collections.uors
@@ -1,0 +1,192 @@
+// Collections with coherence guarantees
+@coherent object CoherentList {
+    size: int;
+    capacity: int;
+    data: int;  // Memory address
+    
+    function new() -> CoherentList {
+        let list = CoherentList();
+        list.size = 0;
+        list.capacity = 10;
+        list.data = allocate(10);
+        return list;
+    }
+    
+    function push(value: int) -> void {
+        if (size >= capacity) {
+            grow();
+        }
+        store(data + size, value);
+        size = size + 1;
+    }
+    
+    function pop() -> int {
+        if (size == 0) {
+            return 0;  // Error case
+        }
+        size = size - 1;
+        return load(data + size);
+    }
+    
+    function get(index: int) -> int {
+        if (index >= size) {
+            return 0;  // Error case
+        }
+        return load(data + index);
+    }
+    
+    function set(index: int, value: int) -> void {
+        if (index < size) {
+            store(data + index, value);
+        }
+    }
+    
+    function grow() -> void {
+        let newCapacity = capacity * 2;
+        let newData = allocate(newCapacity);
+        
+        // Copy old data
+        let i = 0;
+        while (i < size) {
+            store(newData + i, load(data + i));
+            i = i + 1;
+        }
+        
+        free(data);
+        data = newData;
+        capacity = newCapacity;
+    }
+    
+    function clear() -> void {
+        size = 0;
+    }
+    
+    // Coherence check
+    function checkCoherence() -> bool {
+        // Verify internal consistency
+        return size <= capacity;
+    }
+}
+
+@coherent object CoherentMap {
+    size: int;
+    capacity: int;
+    keys: int;    // Memory address for keys
+    values: int;  // Memory address for values
+    
+    function new() -> CoherentMap {
+        let map = CoherentMap();
+        map.size = 0;
+        map.capacity = 16;
+        map.keys = allocate(16);
+        map.values = allocate(16);
+        return map;
+    }
+    
+    function hash(key: int) -> int {
+        // Simple hash function
+        return (key * 2654435761) % capacity;
+    }
+    
+    function put(key: int, value: int) -> void {
+        let index = hash(key);
+        let probes = 0;
+        
+        // Linear probing for collision resolution
+        while (probes < capacity) {
+            let storedKey = load(keys + index);
+            if (storedKey == 0 || storedKey == key) {
+                store(keys + index, key);
+                store(values + index, value);
+                if (storedKey == 0) {
+                    size = size + 1;
+                }
+                return;
+            }
+            index = (index + 1) % capacity;
+            probes = probes + 1;
+        }
+        
+        // Table full, need to resize
+        resize();
+        put(key, value);
+    }
+    
+    function get(key: int) -> int {
+        let index = hash(key);
+        let probes = 0;
+        
+        while (probes < capacity) {
+            let storedKey = load(keys + index);
+            if (storedKey == key) {
+                return load(values + index);
+            }
+            if (storedKey == 0) {
+                return 0;  // Not found
+            }
+            index = (index + 1) % capacity;
+            probes = probes + 1;
+        }
+        return 0;  // Not found
+    }
+    
+    function resize() -> void {
+        let oldKeys = keys;
+        let oldValues = values;
+        let oldCapacity = capacity;
+        
+        capacity = capacity * 2;
+        keys = allocate(capacity);
+        values = allocate(capacity);
+        size = 0;
+        
+        // Rehash all entries
+        let i = 0;
+        while (i < oldCapacity) {
+            let key = load(oldKeys + i);
+            if (key != 0) {
+                put(key, load(oldValues + i));
+            }
+            i = i + 1;
+        }
+        
+        free(oldKeys);
+        free(oldValues);
+    }
+}
+
+// Set operations
+@coherent object Set {
+    map: CoherentMap;
+    
+    function new() -> Set {
+        let set = Set();
+        set.map = CoherentMap.new();
+        return set;
+    }
+    
+    function add(value: int) -> void {
+        map.put(value, 1);
+    }
+    
+    function contains(value: int) -> bool {
+        return map.get(value) != 0;
+    }
+    
+    function remove(value: int) -> void {
+        // Would need delete operation in map
+        map.put(value, 0);
+    }
+    
+    function union(other: Set) -> Set {
+        let result = Set.new();
+        // Implementation would iterate over both sets
+        return result;
+    }
+    
+    function intersection(other: Set) -> Set {
+        let result = Set.new();
+        // Implementation would check membership
+        return result;
+    }
+}

--- a/uor/stdlib/crypto.uors
+++ b/uor/stdlib/crypto.uors
@@ -1,0 +1,39 @@
+// Cryptographic operations
+@coherent object Crypto {
+    // Hash functions
+    function sha256(data: int, size: int) -> int {
+        // Returns hash value
+        // Implementation uses HASH primitive
+    }
+    
+    function sha512(data: int, size: int) -> int {
+        // Extended hash function
+        // Would use multiple HASH calls
+    }
+    
+    // Digital signatures
+    function sign(data: int, privateKey: int) -> int {
+        // Returns signature
+        // Uses SIGN primitive
+    }
+    
+    function verify(data: int, signature: int, publicKey: int) -> bool {
+        // Verifies signature
+        // Uses VERIFY primitive
+    }
+    
+    // Key generation
+    function generateKeyPair() -> int {
+        // Returns address of key pair structure
+        let seed = randomSeed();
+        return generateFromSeed(seed);
+    }
+    
+    function generateFromSeed(seed: int) -> int {
+        // Deterministic key generation
+        let keys = allocate(2);
+        store(keys, derivePrivateKey(seed));
+        store(keys + 1, derivePublicKey(load(keys)));
+        return keys;
+    }
+}

--- a/uor/stdlib/crypto_primitives.asm
+++ b/uor/stdlib/crypto_primitives.asm
@@ -1,0 +1,59 @@
+# Cryptographic VM primitives
+
+# SHA-256 hash
+crypto_sha256:
+    LOAD 0      # data address
+    LOAD 1      # size
+    HASH
+    RET
+
+# Digital signature
+crypto_sign:
+    LOAD 0      # data
+    LOAD 1      # private key
+    SIGN
+    RET
+
+crypto_verify:
+    LOAD 0      # data
+    LOAD 1      # signature
+    LOAD 2      # public key
+    VERIFY
+    RET
+
+# Random number generation for keys
+crypto_random:
+    RNG
+    RET
+
+# AES encryption (simplified)
+aes_encrypt:
+    PUSH 30     # AES encrypt syscall
+    LOAD 0      # plaintext
+    LOAD 1      # key
+    LOAD 2      # size
+    SYSCALL
+    RET
+
+aes_decrypt:
+    PUSH 31     # AES decrypt syscall
+    LOAD 0      # ciphertext
+    LOAD 1      # key
+    LOAD 2      # size
+    SYSCALL
+    RET
+
+# Key derivation
+derive_private_key:
+    LOAD 0      # seed
+    PUSH 123456789
+    MUL
+    HASH
+    RET
+
+derive_public_key:
+    LOAD 0      # private key
+    PUSH 65537  # public exponent
+    MUL
+    HASH
+    RET

--- a/uor/stdlib/io.uors
+++ b/uor/stdlib/io.uors
@@ -1,0 +1,36 @@
+// IO module for input/output operations
+@coherent object IO {
+    // Console operations
+    function print(value: int) -> void {
+        // VM primitive PRINT
+    }
+    
+    function println(value: int) -> void {
+        print(value);
+        // Would print newline if string support existed
+    }
+    
+    function read() -> int {
+        // VM primitive INPUT
+    }
+    
+    // File operations (using memory-mapped IO)
+    function fileOpen(filename: int) -> int {
+        // Returns file handle
+        // Implementation would use SYSCALL
+    }
+    
+    function fileRead(handle: int, size: int) -> int {
+        // Reads data from file
+        // Returns memory address of data
+    }
+    
+    function fileWrite(handle: int, data: int, size: int) -> int {
+        // Writes data to file
+        // Returns bytes written
+    }
+    
+    function fileClose(handle: int) -> void {
+        // Closes file handle
+    }
+}

--- a/uor/stdlib/io_primitives.asm
+++ b/uor/stdlib/io_primitives.asm
@@ -1,0 +1,70 @@
+# IO VM primitive implementations
+
+# Console input
+io_read:
+    INPUT
+    RET
+
+# Console output  
+io_print:
+    LOAD 0  # parameter
+    PRINT
+    RET
+
+# File operations using SYSCALL
+file_open:
+    PUSH 1  # open syscall
+    LOAD 0  # filename address
+    SYSCALL
+    RET
+
+file_read:
+    PUSH 2  # read syscall
+    LOAD 0  # handle
+    LOAD 1  # size
+    SYSCALL
+    RET
+
+file_write:
+    PUSH 3  # write syscall
+    LOAD 0  # handle
+    LOAD 1  # data address
+    LOAD 2  # size
+    SYSCALL
+    RET
+
+file_close:
+    PUSH 4  # close syscall
+    LOAD 0  # handle
+    SYSCALL
+    RET
+
+# Network primitives
+net_connect:
+    PUSH 10  # connect syscall
+    LOAD 0   # address
+    LOAD 1   # port
+    SYSCALL
+    RET
+
+net_send:
+    NET_SEND
+    RET
+
+net_recv:
+    NET_RECV
+    RET
+
+# IPFS integration
+ipfs_add:
+    PUSH 20  # IPFS add syscall
+    LOAD 0   # data address
+    LOAD 1   # size
+    SYSCALL
+    RET
+
+ipfs_get:
+    PUSH 21  # IPFS get syscall
+    LOAD 0   # CID address
+    SYSCALL
+    RET

--- a/uor/stdlib/iterator.asm
+++ b/uor/stdlib/iterator.asm
@@ -1,0 +1,30 @@
+# Iterator protocol implementation
+# Uses stack for iterator state
+
+iterator_init:
+    PUSH 0      # current index
+    PUSH 0      # collection address
+    PUSH 0      # collection size
+    RET
+
+iterator_has_next:
+    LOAD 0      # current index
+    LOAD 2      # collection size
+    SUB
+    JZ has_next_false
+    PUSH 1
+    RET
+has_next_false:
+    PUSH 0
+    RET
+
+iterator_next:
+    LOAD 0      # current index
+    LOAD 1      # collection address
+    ADD
+    LOAD 0      # load value at address
+    LOAD 0      # current index
+    PUSH 1
+    ADD
+    STORE 0     # increment index
+    RET

--- a/uor/stdlib/loader.asm
+++ b/uor/stdlib/loader.asm
@@ -1,0 +1,39 @@
+# Module loading and linking
+
+# Load module from IPFS
+load_module:
+    PUSH 21     # IPFS get syscall
+    LOAD 0      # CID
+    SYSCALL
+    # Parse and link module
+    CALL link_module
+    RET
+
+# Link module symbols
+link_module:
+    # Module structure:
+    # [size][exports_count][export1][export2]...
+    LOAD 0      # module address
+    LOAD 0      # size
+    LOAD 1      # exports count
+    PUSH 0      # current export
+link_loop:
+    # Process each export
+    # ... linking logic ...
+    PUSH 1
+    ADD
+    JMP link_loop
+link_done:
+    RET
+
+# Module cache for performance
+module_cache_add:
+    LOAD 0      # module CID
+    LOAD 1      # module address
+    # Store in cache structure
+    RET
+
+module_cache_get:
+    LOAD 0      # module CID
+    # Lookup in cache
+    RET

--- a/uor/stdlib/math.uors
+++ b/uor/stdlib/math.uors
@@ -1,0 +1,101 @@
+// Math module with NTT optimization for large operations
+@coherent object Math {
+    // Constants
+    PI: float;
+    E: float;
+    
+    // Basic operations with NTT optimization
+    function add(a: int, b: int) -> int {
+        return a + b;
+    }
+    
+    function subtract(a: int, b: int) -> int {
+        return a - b;
+    }
+    
+    function multiply(a: int, b: int) -> int {
+        return a * b;
+    }
+    
+    function divide(a: int, b: int) -> int {
+        if (b == 0) {
+            // Error handling would be implemented here
+            return 0;
+        }
+        return a / b;
+    }
+    
+    // Power function using repeated squaring
+    function pow(base: int, exp: int) -> int {
+        if (exp == 0) { return 1; }
+        if (exp < 0) { return 0; } // Integer division
+        
+        let result = 1;
+        let b = base;
+        let e = exp;
+        
+        while (e > 0) {
+            if (e % 2 == 1) {
+                result = result * b;
+            }
+            b = b * b;
+            e = e / 2;
+        }
+        return result;
+    }
+    
+    // Factorial with memoization
+    function factorial(n: int) -> int {
+        if (n <= 1) { return 1; }
+        return n * factorial(n - 1);
+    }
+    
+    // Greatest Common Divisor using Euclidean algorithm
+    function gcd(a: int, b: int) -> int {
+        while (b != 0) {
+            let temp = b;
+            b = a % b;
+            a = temp;
+        }
+        return a;
+    }
+    
+    // Least Common Multiple
+    function lcm(a: int, b: int) -> int {
+        return (a * b) / gcd(a, b);
+    }
+    
+    // Square root using Newton's method (integer approximation)
+    function sqrt(n: int) -> int {
+        if (n < 0) { return 0; }
+        if (n == 0) { return 0; }
+        
+        let x = n;
+        let y = (x + 1) / 2;
+        
+        while (y < x) {
+            x = y;
+            y = (x + n / x) / 2;
+        }
+        return x;
+    }
+    
+    // Absolute value
+    function abs(n: int) -> int {
+        if (n < 0) {
+            return -n;
+        }
+        return n;
+    }
+    
+    // Min and Max
+    function min(a: int, b: int) -> int {
+        if (a < b) { return a; }
+        return b;
+    }
+    
+    function max(a: int, b: int) -> int {
+        if (a > b) { return a; }
+        return b;
+    }
+}

--- a/uor/stdlib/math_advanced.asm
+++ b/uor/stdlib/math_advanced.asm
@@ -1,0 +1,47 @@
+# Advanced math operations requiring VM primitives
+# These would be linked to the Math object methods
+
+# Trigonometric functions using Taylor series
+sin:
+    # Implementation using series expansion
+    # sin(x) = x - x³/3! + x⁵/5! - x⁷/7! + ...
+    PUSH 0  # accumulator
+    # ... series computation ...
+    RET
+
+cos:
+    # cos(x) = 1 - x²/2! + x⁴/4! - x⁶/6! + ...
+    PUSH 1  # accumulator
+    # ... series computation ...
+    RET
+
+tan:
+    # tan(x) = sin(x) / cos(x)
+    CALL sin
+    CALL cos
+    DIV
+    RET
+
+# Random number generation using Linear Congruential Generator
+random_seed:
+    PUSH 12345
+    STORE 1000  # seed storage
+    RET
+
+random:
+    LOAD 1000   # get seed
+    PUSH 1103515245
+    MUL
+    PUSH 12345
+    ADD
+    PUSH 2147483648
+    MOD
+    STORE 1000  # store new seed
+    RET
+
+# Matrix operations with coherence
+matrix_multiply_ntt:
+    # Uses NTT for efficient large matrix multiplication
+    NTT 16      # Process 16 chunks with NTT
+    # ... multiplication logic ...
+    RET

--- a/uor/stdlib/memory.asm
+++ b/uor/stdlib/memory.asm
@@ -1,0 +1,82 @@
+# Memory management helpers
+
+# Allocate memory with coherence tracking
+allocate:
+    LOAD 0      # size
+    ALLOC
+    # Add coherence metadata
+    PUSH 1      # coherence flag
+    STORE 0
+    RET
+
+# Free memory with coherence cleanup
+free:
+    LOAD 0      # address
+    # Clear coherence metadata
+    PUSH 0
+    STORE 0
+    FREE
+    RET
+
+# Memory copy
+memcpy:
+    LOAD 0      # destination
+    LOAD 1      # source
+    LOAD 2      # size
+copy_loop:
+    LOAD 2      # size
+    JZ copy_done
+    LOAD 1      # source
+    LOAD 0      # value at source
+    LOAD 0      # destination
+    STORE 0     # store value
+    # Increment pointers
+    LOAD 0
+    PUSH 1
+    ADD
+    STORE 0
+    LOAD 1
+    PUSH 1
+    ADD
+    STORE 1
+    LOAD 2
+    PUSH 1
+    SUB
+    STORE 2
+    JMP copy_loop
+copy_done:
+    RET
+
+# Memory compare
+memcmp:
+    LOAD 0      # addr1
+    LOAD 1      # addr2
+    LOAD 2      # size
+cmp_loop:
+    LOAD 2
+    JZ cmp_equal
+    LOAD 0
+    LOAD 0      # value1
+    LOAD 1
+    LOAD 0      # value2
+    SUB
+    JNZ cmp_done
+    # Increment pointers
+    LOAD 0
+    PUSH 1
+    ADD
+    STORE 0
+    LOAD 1
+    PUSH 1
+    ADD
+    STORE 1
+    LOAD 2
+    PUSH 1
+    SUB
+    STORE 2
+    JMP cmp_loop
+cmp_equal:
+    PUSH 0
+    RET
+cmp_done:
+    RET

--- a/uor/stdlib/test.uors
+++ b/uor/stdlib/test.uors
@@ -1,0 +1,30 @@
+// Simple testing framework
+@coherent object Test {
+    passed: int;
+    failed: int;
+    
+    function new() -> Test {
+        let t = Test();
+        t.passed = 0;
+        t.failed = 0;
+        return t;
+    }
+    
+    function assert(condition: bool, message: int) -> void {
+        if (condition) {
+            passed = passed + 1;
+        } else {
+            failed = failed + 1;
+            IO.print(message);
+        }
+    }
+    
+    function assertEqual(expected: int, actual: int) -> void {
+        assert(expected == actual, 1);
+    }
+    
+    function summary() -> void {
+        IO.print(passed);
+        IO.print(failed);
+    }
+}


### PR DESCRIPTION
## Summary
- implement a UOR-Script standard library under `uor/stdlib`
- include math, IO, collections and crypto modules with assembly primitives
- add memory and loader helpers plus basic test framework
- document the standard library and provide example usage

## Testing
- `python3 -m unittest discover -v`