### PR TITLE
Implement additional VM opcodes

### DIFF
--- a/assembler.py
+++ b/assembler.py
@@ -54,6 +54,20 @@ def assemble(text: str) -> List[int]:
             result.append(chunks.chunk_or())
         elif op == "XOR":
             result.append(chunks.chunk_xor())
+        elif op == "NOT":
+            result.append(chunks.chunk_not())
+        elif op == "GT":
+            result.append(chunks.chunk_gt())
+        elif op == "LT":
+            result.append(chunks.chunk_lt())
+        elif op == "EQ":
+            result.append(chunks.chunk_eq())
+        elif op == "NEQ":
+            result.append(chunks.chunk_neq())
+        elif op == "GTE":
+            result.append(chunks.chunk_gte())
+        elif op == "LTE":
+            result.append(chunks.chunk_lte())
         elif op == "SHL":
             result.append(chunks.chunk_shl())
         elif op == "SHR":
@@ -92,6 +106,18 @@ def assemble(text: str) -> List[int]:
             result.append(chunks.chunk_debug())
         elif op == "ATOMIC":
             result.append(chunks.chunk_atomic())
+        elif op == "DUP":
+            result.append(chunks.chunk_dup())
+        elif op == "SWAP":
+            result.append(chunks.chunk_swap())
+        elif op == "ROT":
+            result.append(chunks.chunk_rot())
+        elif op == "DROP":
+            result.append(chunks.chunk_drop())
+        elif op == "OVER":
+            result.append(chunks.chunk_over())
+        elif op == "PICK":
+            result.append(chunks.chunk_pick())
         elif op == "PRINT":
             result.append(chunks.chunk_print())
         elif op == "LOAD":

--- a/chunks.py
+++ b/chunks.py
@@ -9,7 +9,7 @@ from primes import get_prime, _PRIME_IDX
 from primes import _PRIMES
 from primes import _extend_primes_to
 
-_extend_primes_to(54)
+_extend_primes_to(67)
 OP_PUSH, OP_ADD, OP_PRINT = _PRIMES[0], _PRIMES[1], _PRIMES[2]
 OP_SUB, OP_MUL = _PRIMES[6], _PRIMES[7]
 OP_LOAD, OP_STORE = _PRIMES[8], _PRIMES[9]
@@ -32,6 +32,11 @@ OP_NOP, OP_HASH, OP_SIGN = _PRIMES[46], _PRIMES[47], _PRIMES[48]
 OP_VERIFY, OP_RNG, OP_BRK = _PRIMES[49], _PRIMES[50], _PRIMES[51]
 OP_TRACE = _PRIMES[52]
 OP_DEBUG, OP_ATOMIC = _PRIMES[53], _PRIMES[54]
+OP_NOT, OP_GT, OP_LT = _PRIMES[55], _PRIMES[56], _PRIMES[57]
+OP_EQ, OP_NEQ, OP_GTE = _PRIMES[58], _PRIMES[59], _PRIMES[60]
+OP_LTE, OP_DUP, OP_SWAP = _PRIMES[61], _PRIMES[62], _PRIMES[63]
+OP_ROT, OP_DROP, OP_OVER = _PRIMES[64], _PRIMES[65], _PRIMES[66]
+OP_PICK = _PRIMES[67]
 BLOCK_TAG, NTT_TAG, T_MOD = _PRIMES[3], _PRIMES[4], _PRIMES[5]
 NTT_ROOT = 2
 
@@ -315,3 +320,55 @@ def chunk_debug() -> int:
 
 def chunk_atomic() -> int:
     return _attach_checksum(OP_ATOMIC ** 4, [(OP_ATOMIC, 4)])
+
+
+def chunk_not() -> int:
+    return _attach_checksum(OP_NOT ** 4, [(OP_NOT, 4)])
+
+
+def chunk_gt() -> int:
+    return _attach_checksum(OP_GT ** 4, [(OP_GT, 4)])
+
+
+def chunk_lt() -> int:
+    return _attach_checksum(OP_LT ** 4, [(OP_LT, 4)])
+
+
+def chunk_eq() -> int:
+    return _attach_checksum(OP_EQ ** 4, [(OP_EQ, 4)])
+
+
+def chunk_neq() -> int:
+    return _attach_checksum(OP_NEQ ** 4, [(OP_NEQ, 4)])
+
+
+def chunk_gte() -> int:
+    return _attach_checksum(OP_GTE ** 4, [(OP_GTE, 4)])
+
+
+def chunk_lte() -> int:
+    return _attach_checksum(OP_LTE ** 4, [(OP_LTE, 4)])
+
+
+def chunk_dup() -> int:
+    return _attach_checksum(OP_DUP ** 4, [(OP_DUP, 4)])
+
+
+def chunk_swap() -> int:
+    return _attach_checksum(OP_SWAP ** 4, [(OP_SWAP, 4)])
+
+
+def chunk_rot() -> int:
+    return _attach_checksum(OP_ROT ** 4, [(OP_ROT, 4)])
+
+
+def chunk_drop() -> int:
+    return _attach_checksum(OP_DROP ** 4, [(OP_DROP, 4)])
+
+
+def chunk_over() -> int:
+    return _attach_checksum(OP_OVER ** 4, [(OP_OVER, 4)])
+
+
+def chunk_pick() -> int:
+    return _attach_checksum(OP_PICK ** 4, [(OP_PICK, 4)])

--- a/tests/test_vm_enhanced.py
+++ b/tests/test_vm_enhanced.py
@@ -43,6 +43,78 @@ class VMEnhancedTest(unittest.TestCase):
             out = ''.join(vm.execute(prog))
             self.assertEqual(out, '1')
 
+    def test_comparison_and_not_ops(self):
+        prog = [
+            chunks.chunk_push(5),
+            chunks.chunk_not(),
+            chunks.chunk_print(),
+            chunks.chunk_push(3),
+            chunks.chunk_push(2),
+            chunks.chunk_gt(),
+            chunks.chunk_print(),
+            chunks.chunk_push(2),
+            chunks.chunk_push(3),
+            chunks.chunk_lt(),
+            chunks.chunk_print(),
+            chunks.chunk_push(5),
+            chunks.chunk_push(5),
+            chunks.chunk_eq(),
+            chunks.chunk_print(),
+            chunks.chunk_push(4),
+            chunks.chunk_push(5),
+            chunks.chunk_neq(),
+            chunks.chunk_print(),
+            chunks.chunk_push(3),
+            chunks.chunk_push(2),
+            chunks.chunk_gte(),
+            chunks.chunk_print(),
+            chunks.chunk_push(3),
+            chunks.chunk_push(3),
+            chunks.chunk_lte(),
+            chunks.chunk_print(),
+        ]
+        out = ''.join(VM().execute(decode(prog)))
+        self.assertEqual(out, '-6111111')
+
+    def test_stack_manipulation_ops(self):
+        prog = [
+            chunks.chunk_push(1),
+            chunks.chunk_dup(),
+            chunks.chunk_add(),
+            chunks.chunk_print(),
+            chunks.chunk_push(2),
+            chunks.chunk_push(3),
+            chunks.chunk_swap(),
+            chunks.chunk_sub(),
+            chunks.chunk_print(),
+            chunks.chunk_push(4),
+            chunks.chunk_push(5),
+            chunks.chunk_push(6),
+            chunks.chunk_rot(),
+            chunks.chunk_drop(),
+            chunks.chunk_print(),
+            chunks.chunk_drop(),
+            chunks.chunk_push(7),
+            chunks.chunk_push(8),
+            chunks.chunk_over(),
+            chunks.chunk_sub(),
+            chunks.chunk_print(),
+            chunks.chunk_drop(),
+            chunks.chunk_push(9),
+            chunks.chunk_push(10),
+            chunks.chunk_push(11),
+            chunks.chunk_push(12),
+            chunks.chunk_push(2),
+            chunks.chunk_pick(),
+            chunks.chunk_print(),
+            chunks.chunk_drop(),
+            chunks.chunk_drop(),
+            chunks.chunk_drop(),
+            chunks.chunk_drop(),
+        ]
+        out = ''.join(VM().execute(decode(prog)))
+        self.assertEqual(out, '216110')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add prime constants for new opcodes and helpers
- implement comparison and stack ops in the VM
- map new opcodes in the dispatch table
- extend assembler keywords
- test new operations

## Testing
- `pytest -q tests/test_vm_enhanced.py`
- `pytest -q`