### PR TITLE
Add segmented memory permissions and helpers

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -12,6 +12,31 @@ class SegmentedMemoryTest(unittest.TestCase):
         with self.assertRaises(MemoryError):
             mem.load(SegmentedMemory.STACK_START + SegmentedMemory.STACK_SIZE + 10)
 
+    def test_permission_enforcement(self):
+        mem = SegmentedMemory()
+        mem.load_code([1])
+        with self.assertRaises(MemoryError):
+            mem.store(mem.CODE_START, 3)
+        with self.assertRaises(MemoryError):
+            mem.load(mem.MMIO_OUT)
+        with self.assertRaises(MemoryError):
+            mem.store(mem.MMIO_IN, 1)
+
+    def test_allocate_helpers(self):
+        mem = SegmentedMemory()
+        sp = mem.stack_pointer
+        addr_s = mem.allocate_stack(4)
+        self.assertEqual(addr_s, sp)
+        self.assertEqual(mem.stack_pointer, sp + 4)
+        hp = mem.heap_pointer
+        addr_h = mem.allocate_heap(8)
+        self.assertEqual(addr_h, hp)
+        self.assertEqual(mem.heap_pointer, hp + 8)
+        mem.store(addr_s, 1)
+        mem.store(addr_h, 2)
+        self.assertEqual(mem.load(addr_s), 1)
+        self.assertEqual(mem.load(addr_h), 2)
+
     def test_gc(self):
         mem = SegmentedMemory()
         a1 = mem.allocate(10)

--- a/uor/vm/coherence.py
+++ b/uor/vm/coherence.py
@@ -30,7 +30,8 @@ class CoherenceValidator:
     # Helpers
     # ------------------------------------------------------------------
     def _checksum(self, vm) -> float:
-        return float(sum(vm.stack) + sum(vm.mem.storage.values()) + vm.ip)
+        mem_sum = sum(vm.mem.dump().values())
+        return float(sum(vm.stack) + mem_sum + vm.ip)
 
     def start(self, vm) -> None:
         self._last_checksum = self._checksum(vm)

--- a/vm.py
+++ b/vm.py
@@ -51,6 +51,8 @@ class VM:
         self.ds = self.mem.DATA_START
         self.hs = self.mem.HEAP_START
         self.ss = self.mem.STACK_START
+        self.hp = self.mem.heap_pointer
+        self.sp = self.mem.stack_pointer
         self.ip: int = 0
         self.call_stack: List[int] = []
         self.io_in: List[int] = []


### PR DESCRIPTION
## Summary
- introduce `MemorySegment` enum and restructure segmented memory
- enforce read/write permissions in `load` and `store`
- add `allocate_heap` and `allocate_stack` helpers
- expose heap and stack pointers to `VM`
- adjust coherence checksum logic
- expand memory unit tests

## Testing
- `pytest -q`